### PR TITLE
CI: shared version counter and PR package publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,25 +12,26 @@ variables:
   buildConfiguration: 'Release'
   NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
   isNotaPR: $[ne(variables['Build.Reason'], 'PullRequest')]
+  # One counter for every channel, keyed on major.minor - the master counter's existing
+  # key, so the sequence continues without a seed. A shared counter means a PR
+  # 1.3.7-pr.12.3456 and a release 1.3.8 can never carry the same patch number, so
+  # AssemblyVersion (which drops the suffix) cannot collide across channels either.
+  # The suffix still names the channel; PR versions also name their PR and build.
+  patch: $[counter(format('{0}.{1}', variables['Major'], variables['Minor']), 0)]
   ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    versionSuffix: '-PR'
-    patch: $[counter(format('{0}.{1}.{2}', variables['Major'], variables['Minor'], variables['versionSuffix']), 0)]
-    packageVersion: $[format('{0}.{1}.{2}-PR', variables['major'], variables['minor'], variables['patch']) ]
+    packageVersion: $[format('{0}.{1}.{2}-pr.{3}.{4}', variables['major'], variables['minor'], variables['patch'], variables['System.PullRequest.PullRequestNumber'], variables['Build.BuildId'])]
     buildName: $[ format('PR {0}', variables['packageVersion']) ]
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
       # full release
-      patch: $[counter(format('{0}.{1}', variables['Major'], variables['Minor']), 0)]
       packageVersion: $[format('{0}.{1}.{2}', variables['major'], variables['minor'], variables['patch']) ]
-      buildName: $[ format('🚀 Release {0}', variables['packageVersion']) ]      
+      buildName: $[ format('🚀 Release {0}', variables['packageVersion']) ]
 
     ${{ if ne(variables['Build.SourceBranchName'], 'master') }}:
       # a branch
-      patch: $[counter(format('{0}.{1}.{2} branch', variables['Major'], variables['Minor'], variables['Build.SourceBranchName']), 0)]
       packageVersion: $[format('{0}.{1}.{2}-branch', variables['major'], variables['minor'], variables['patch']) ]
       buildName: $[ format('Branch {0} -- {1}', variables['Build.SourceBranchName'], variables['patch']) ]
-  # packageVersion: $(major).$(minor).$(versionSuffix)$(patch)
-    
+
 
 name: $(buildName)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
+# CI on master only; PRs are covered by the default PR validation trigger.
+# With '*', every PR queued two builds of the same code (branch push + PR
+# validation), and the branch build published a -branch package nothing
+# consumes. Same reasoning as WldMr.Web's pipeline.
 trigger:
-- '*'
+- master
 
 pool:
   name: Azure Pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,9 +115,11 @@ steps:
     tag: $(packageVersion)
 
 
+# PR builds publish too: a -pr package on the internal feed is what lets a
+# downstream repo verify against this change before it merges.
 - task: DotNetCoreCLI@2
   displayName: 'dotnet push ▶ Azure artifacts'
-  condition: and(succeeded(), eq(variables.isNotaPR, true), eq(variables['Build.Repository.Uri'], 'https://github.com/WieldMore-io/WldMr.Numerics'))
+  condition: and(succeeded(), eq(variables['Build.Repository.Uri'], 'https://github.com/WieldMore-io/WldMr.Numerics'))
   inputs:
     command: 'push'
     packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,16 +21,14 @@ variables:
   ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     packageVersion: $[format('{0}.{1}.{2}-pr.{3}.{4}', variables['major'], variables['minor'], variables['patch'], variables['System.PullRequest.PullRequestNumber'], variables['Build.BuildId'])]
     buildName: $[ format('PR {0}', variables['packageVersion']) ]
-  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-    ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-      # full release
-      packageVersion: $[format('{0}.{1}.{2}', variables['major'], variables['minor'], variables['patch']) ]
-      buildName: $[ format('🚀 Release {0}', variables['packageVersion']) ]
-
-    ${{ if ne(variables['Build.SourceBranchName'], 'master') }}:
-      # a branch
-      packageVersion: $[format('{0}.{1}.{2}-branch', variables['major'], variables['minor'], variables['patch']) ]
-      buildName: $[ format('Branch {0} -- {1}', variables['Build.SourceBranchName'], variables['patch']) ]
+  ${{ elseif eq(variables['Build.SourceBranchName'], 'master') }}:
+    # full release
+    packageVersion: $[format('{0}.{1}.{2}', variables['major'], variables['minor'], variables['patch']) ]
+    buildName: $[ format('🚀 Release {0}', variables['packageVersion']) ]
+  ${{ else }}:
+    # a branch
+    packageVersion: $[format('{0}.{1}.{2}-branch', variables['major'], variables['minor'], variables['patch']) ]
+    buildName: $[ format('Branch {0} -- {1}', variables['Build.SourceBranchName'], variables['patch']) ]
 
 
 name: $(buildName)


### PR DESCRIPTION
Two CI changes toward cross-repo PR verification:

- **One version counter for every channel**, keyed on `major.minor` — the master counter's existing key, so the sequence continues without a seed. The suffix names the channel; PR builds version as `X.Y.Z-pr.<PR>.<buildId>`. This also removes two collision paths: two branches' first builds both minting `X.Y.0-branch`, and PR/branch AssemblyVersions shadowing same-numbered releases once the suffix is dropped.
- **PR builds now push their package to the internal feed**, so a downstream repo can pin it and verify against this change before it merges. Feed retention (100 versions/package) reaps the churn; the versions consumers adopt are promoted to `@Release` from the consumer side.

This PR's own build demonstrates the scheme: the build name should read `PR X.Y.Z-pr.<thisPR>.<buildId>` and that package should appear on the feed.
