### PR TITLE
CI: keep Build.BuildId out of the PR run name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,12 @@ variables:
   patch: $[counter(format('{0}.{1}', variables['Major'], variables['Minor']), 0)]
   ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     packageVersion: $[format('{0}.{1}.{2}-pr.{3}.{4}', variables['major'], variables['minor'], variables['patch'], variables['System.PullRequest.PullRequestNumber'], variables['Build.BuildId'])]
-    buildName: $[ format('PR {0}', variables['packageVersion']) ]
+    # Build.BuildId reads empty when the orchestrator evaluates the run name
+    # (same scoping as Build.Repository.Uri), so naming the run after
+    # packageVersion yields "PR 1.5.34-pr.673." - invalid, warned, and
+    # replaced with a default name. Steps evaluate packageVersion on the
+    # agent, where the id is real - only the run name must live without it.
+    buildName: $[ format('PR {0}.{1}.{2}-pr.{3}', variables['major'], variables['minor'], variables['patch'], variables['System.PullRequest.PullRequestNumber']) ]
   ${{ elseif eq(variables['Build.SourceBranchName'], 'master') }}:
     # full release
     packageVersion: $[format('{0}.{1}.{2}', variables['major'], variables['minor'], variables['patch']) ]


### PR DESCRIPTION
Every PR build warned `The build number format string $(buildName) generated a build number PR <ver>-pr.<n>. which ... ends with '.'` and fell back to a default run name: the orchestrator evaluates `name:` with `Build.BuildId` empty (same variable scoping as the `Build.Repository.Uri` fence lesson), and the PR-case `buildName` chained to `packageVersion`, whose last segment is the id.

The run name now uses only the parts that resolve at orchestration (`PR <major>.<minor>.<patch>-pr.<prNumber>`); `packageVersion` keeps the id — steps evaluate it on the agent, where it is real.

This PR's own validation build demonstrates the fix: its run name should read `PR x.y.z-pr.<n>` with 0 warnings, instead of `yyyymmdd.r` with 1.