### PR TITLE
CI: GithubRelease@0 -> @1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,13 +105,13 @@ steps:
     artifactName: 'nuget package'
 
 
-- task: GithubRelease@0
+- task: GithubRelease@1
   displayName: 'Create GitHub Release'
   condition: and(succeeded(), eq(variables.isNotaPR, true), eq(variables['Build.Repository.Uri'], 'https://github.com/WieldMore-io/WldMr.Numerics'))
   inputs:
     gitHubConnection: github.com_PierreYvesR
     repositoryName: WieldMore-io/WldMr.Numerics
-    tagSource: manual
+    tagSource: userSpecifiedTag # was `manual` - renamed in @1
     addChangeLog: false
     #isPreRelease: true
     tag: $(packageVersion)


### PR DESCRIPTION
The `GithubRelease@0` task is deprecated and warns twice at job initialization on **every** build — PR builds included, since init-time warnings ignore step conditions (these were the two residual warnings on the PR validation builds). Same task shape as WldMr.Analytics already uses; `tagSource: manual` is `userSpecifiedTag` in @1, everything else carries over unchanged.

This PR's validation build should report **0 warnings** in its summary (was 2 after the run-name fix, 3 before).