### PR TITLE
AD: accumulate adjoints in place on reverse push

### DIFF
--- a/plans/ad-tape-allocation.md
+++ b/plans/ad-tape-allocation.md
@@ -1,11 +1,20 @@
 # Reverse-mode AD allocates ~2.5x what it needs to
 
-**Status: diagnosed, not fixed, 2026-08-05.** A harness exists
-(`consoles/BenchmarkAdTape`) and the cause is confirmed at three specific lines.
-Nobody has attempted a fix. This document is the hand-over. Reviewed against the
-code 2026-08-05, then step 1 — the `adjoint`/`.A` consumer audit — was executed
-the same day (section at the end). The audit's corrections supersede the
-review's `jacobian'` claim and are applied throughout the body.
+**Status: steps 1 and 2 landed 2026-08-07 (PR #18); step 4 followed the same
+day — see the step-4 section at the end. Step 3 is next, minding the
+empty-destination interaction described there.**
+
+History: diagnosed 2026-08-05 with a harness (`consoles/BenchmarkAdTape`) and
+the cause confirmed at three specific lines. Step 1, the `adjoint`/`.A` consumer
+audit, ran the same day; its corrections supersede the original review's
+`jacobian'` claim and are applied throughout the body. Step 2 — buffer reuse on
+reset plus the guarded copy in `adjoint` — shipped 2026-08-07.
+
+**Numbers *and line references* in the body below are pre-step-2.** They are
+kept because they are what motivated the work, but steps 2 and 4 both inserted
+lines into `AD.Lite.fs`, so every `:NNNN` in the body is stale — find the sites
+by name with `rg` instead. The step-4 section at the end carries the current
+allocation baseline and the verification recipe. Use those.
 
 ## Why this is worth doing
 
@@ -233,25 +242,28 @@ is a plain `DV` (and, for push, `v` too), falling back to allocation otherwise.
 
 ## Suggested order
 
-1. **Audit `adjoint` / `.A` consumers** — **done 2026-08-05**, full findings in
+1. ~~**Audit `adjoint` / `.A` consumers**~~ — **done 2026-08-05**, full findings in
    the audit section at the end. All eleven repos swept; contract adopted: an
    adjoint obtained through `adjoint` is the caller's own value, `.A` is the
    raw accessor and aliases the tape. Nothing below is blocked any more.
-2. **`:3428` + `:3530` + copy-at-boundary, as one indivisible change** — reuse
-   the buffer only when the existing value is a plain `DV`/`DM` of the right
-   length (constraint 5), behind the Fable guard, *and* make `adjoint`
-   (`:3346`) return a guarded copy in the same commit — reuse without the copy
-   breaks Analytics' `CurveSolver.ff'` (constraint 3, audit correction 2).
-   `-- width` already tells you exactly what it should buy.
+2. ~~**`:3428` + `:3530` + copy-at-boundary, as one indivisible change**~~ —
+   **done 2026-08-07, PR #18.** Reuse guarded on a plain `DV`/`DM(ColMajor)` of
+   matching shape (constraint 5), behind the Fable guard, with `adjoint`
+   (`:3346`) returning a copy for exactly the same case split, in the same
+   commit. Reset allocation went 115,656 → 2,136 B/pass and is now flat in
+   vector width. Cross-runtime tests in `tests/ExpectoTests/AdjointLifetimeTests.fs`.
 3. **`:576`** — if reset reuses buffers, question whether construction needs to
    allocate one eagerly at all. Mind the interaction with step 4: a non-empty
    contribution accumulated into an empty sentinel adjoint is
    `Backend.Add_V_V_Inplace`'s error path. Reset runs before every push
    (`:3996`), so "buffers are full-length by push time" holds — keep that
    invariant explicit.
-4. **`:3746`** — in-place adjoint accumulation. Biggest single win (push is ~2x
-   reset) and the most invasive; the dormant `DV.Add_V_V_Inplace` (`:906`) plus
-   the backend primitives are most of the machinery.
+4. ~~**`:3746`** — in-place adjoint accumulation.~~ — **done 2026-08-07.** The
+   `DV` and `DM` central accumulates now go through the previously dormant
+   `Add_V_V_Inplace`/`Add_M_M_Inplace`; push went 227,432 → 115,472 B/pass
+   (16.87 → 8.57 B/slot, i.e. each slot's value is now allocated once — the
+   derivative payload — instead of twice). Details in the step-4 section at
+   the end.
 5. **Reset per reverse pass (`:3996`)** — the multiplier, potentially worth more
    than 2-4 combined for multi-seed workloads. It has two separable levers, and
    they live in different repos:
@@ -534,3 +546,117 @@ of a public `[<AutoOpen>]` API.
 - Step 5 gains the `jacobian'` finding: N+1 forward passes per N-row Jacobian.
 
 All four applied to the body, 2026-08-05.
+
+## Step 4: in-place adjoint accumulation — landed 2026-08-07
+
+This section replaces the step-4 hand-over that previously stood here; it keeps
+only what later steps still need.
+
+### What changed
+
+The `DV` and `DM` central accumulates in `pushRec` — nothing else:
+
+```fsharp
+dARef.Value <- DV.Add_V_V_Inplace(v, dARef.Value)   // was: dARef.Value + v
+dARef.Value <- DM.Add_M_M_Inplace(v, dARef.Value)
+```
+
+The previously dormant `*_Inplace` members pass the same `fd`/`df_*`/`r_*`
+lambdas as `(+)`, so every mixed case (`DVF`/`DVR`/`DMF`/`DMR` on either side —
+constraint 5) dispatches exactly as before; only both-plain changes, to a
+destructive `daxpy` into the buffer reset leaves in place. They are destructive
+of their **second** argument, hence `v` first.
+
+Two facts made this smaller than the plan feared:
+
+- **The preconditions were already the site's own.** `Backend.Add_V_V` /
+  `GenMat.addM` at the same site already errored on the same shape mismatches —
+  `addM` even required `ColMajor` on *both* sides where in-place needs it only
+  on the destination. The one narrowing: an empty destination receiving a
+  non-empty contribution now errors instead of copying. A consistent graph
+  cannot produce that today, but it becomes the live error path if step 3
+  removes the eager allocation at `DV.R` — that is the step-3 interaction to
+  mind.
+- **Identity pushes were secretly expensive.** `Add_V_V`/`Mat.addM` with an
+  empty operand return a full copy of the other side, so every
+  `bxv DV.Zero a` / `bxm DM.Zero a` bookkeeping push (all the slicing ops emit
+  them) copied the entire adjoint. They are now no-ops.
+
+Deliberately left alone: the scalar `D` accumulate (an immutable scalar cannot
+accumulate in place) and the sixteen `.A <-` bypass sites in `pushRec`
+(`rg '\.A <-' AD.Lite.fs`). Push now costs ~8 B per adjoint slot — exactly one
+allocation per slot, the derivative payload itself (`dA .* b.P`, `-dA`, …).
+Going below that means fusing derivative computation into the accumulate (the
+structured-expression TODO at the `Sub_DM_DM` push site), a different and much
+larger change; in this op mix the bypass sites are inside the noise. Whoever
+does convert them must re-establish what made the central sites safe: the
+destination buffer is uniquely owned by its node, and a pushed contribution is
+only ever read.
+
+### Current baseline — what step 3 measures against
+
+`-- phases 8`, B/pass: forward 229,040 · reset 2,136 · push 115,472 ·
+reverseProp 117,608. Push was 227,432 (16.87 B/slot) before this step.
+
+BDN depth 8 `Allocated`: Forward 223.67 KB (1.00) · ForwardAndReset 225.76
+(1.01) · ForwardResetAndPush 338.88 (1.52) · ForwardThenSeedPasses ×8 1142.84
+(5.11).
+
+Downstream (`BenchmarkMarketBuild -- stages 20`, warm shared world): whole fit
+**74.0 MB**, `fitMktData` **47.0 MB** — from 86.6 / 59.8 before this work
+started, −14.6% cumulative, all of it inside curve fitting.
+
+### The failure signature changed — keep the tests honest
+
+With an in-place push, a broken `adjoint` copy no longer reads stale zeros; it
+**aliases the live buffer** — and a same-seed rerun refills an aliased buffer
+with identical values, which reads as green. That caught the DM lifetime test,
+which seeded both passes with `D.One`; it now seeds the second pass `D 3.0`.
+The rule for any test here: assert on values, distinct seeds (or functions) per
+pass, never reference identity. The copy-neutralisation drill — temporarily
+drop the copies in `DOps.adjoint`, expect the three survival tests red —
+verifies a test is load-bearing; it was re-run after the seeding fix.
+
+### Verification recipe (worked for steps 2 and 4, unchanged)
+
+```bash
+# in-repo
+dotnet test                                        # 16 + 11 + 35 pass, 6 skipped
+npm test                                           # Fable→JS, 11 passing
+dotnet fable tests/ExpectoTests --lang python -o py-build/tests/ExpectoTests \
+  && python3 py-build/tests/ExpectoTests/main.py   # 11 passing
+
+cd consoles/BenchmarkAdTape
+dotnet run -c Release -- phases 8
+dotnet run -c Release -- width
+dotnet run -c Release                              # BDN headline, ~7 min
+
+# downstream
+/git/wldmr-dev/scripts/local-feed.sh pack WldMr.Numerics WldMr.Analytics
+/git/wldmr-dev/scripts/local-feed.sh use  WldMr.Analytics
+# in WldMr.Analytics: dotnet test (445), npm test (222), then in
+# consoles/BenchmarkMarketBuild: -- fingerprint and -- stages 20
+/git/wldmr-dev/scripts/local-feed.sh clear         # always
+```
+
+**Expected fingerprint:
+`15a6fee33a346e31be9e6de14de49e968ea71958bdd5193885939d9d2c0cf52d`** — stable
+across stock, step 2 and step 4; any change to it is a real numerical
+regression, not noise.
+
+Gotchas that cost time, all still live: `local-feed.sh` is not on PATH (use the
+full path above); `-- stages 5` is JIT-contaminated, use 20 reps; don't pipe
+the BDN run through `tail`; Analytics' `npm test` runs three suites, redirect
+to a file and grep; `GenMat.addM`/`mulM` are `failwith "todo"` off the
+ColMajor+ColMajor diagonal, so DM experiments hit holes unrelated to AD.
+
+### Then what
+
+Step 3 (`DV.R`'s eager zero-vector) — mind the empty-destination interaction
+above. Step 5's in-library half is independent and cheap: `jacobian'` re-runs
+the whole forward pass per Jacobian row because `let r = jacobianTv f x` is a
+partial application; holding `jacobianTv''`'s `r2` fixes it.
+
+Adoption: `WldMr.Analytics` pins with `lowest_matching`, so it moves onto none
+of this by itself — it needs an explicit `>= x.y.z` minimum. See the
+`wldmr-cross-repo-dev` and `wldmr-analytics-release` skills.

--- a/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
+++ b/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
@@ -3780,7 +3780,11 @@ module DOps =
                     match d with
                     | DVR(_, dARef, o, dFanOutRef, _) ->
                         dFanOutRef.Value <- dFanOutRef.Value - 1u
-                        dARef.Value <- dARef.Value + v
+                        // Accumulate into the buffer reset left in place instead of allocating
+                        // a fresh vector per contribution. `Add_V_V_Inplace` is destructive of
+                        // its *second* argument and shares `(+)`'s dispatch otherwise, so the
+                        // nested-AD cases (`DVF`/`DVR` on either side) still allocate as before.
+                        dARef.Value <- DV.Add_V_V_Inplace(v, dARef.Value)
                         let dA = dARef.Value
                         // If all incoming parts of the adjoint have been received, then proceed to the children
                         if dFanOutRef.Value = 0u then
@@ -3902,7 +3906,10 @@ module DOps =
                     match d with
                     | DMR(_, dARef, o, dFanOutRef, _) ->
                         dFanOutRef.Value <- dFanOutRef.Value - 1u
-                        dARef.Value <- dARef.Value + v
+                        // As for `DV` above. The destination is the post-reset buffer, always
+                        // `ColMajor` — the only shape `AlphaAdd_M_M_Inplace'` updates in place —
+                        // while the source side goes through `GenMat.toMat`, which takes any.
+                        dARef.Value <- DM.Add_M_M_Inplace(v, dARef.Value)
                         let dA = dARef.Value
                         // If all incoming parts of the adjoint have been received, then proceed to the children
                         if dFanOutRef.Value = 0u then

--- a/tests/ExpectoTests/AdjointLifetimeTests.fs
+++ b/tests/ExpectoTests/AdjointLifetimeTests.fs
@@ -53,17 +53,19 @@ let tests =
     testCase "DM adjoint survives a later reverse pass over the same node" <| fun _ ->
       let m = DM (Mat.ofRowsArray [| [| 1.0; 2.0 |]; [| 3.0; 4.0 |] |] |> ColMajor)
       let ma = m |> makeReverse (nextTag ())
-      let pass () =
+      // A different seed per pass: with an in-place push, a same-seed rerun refills
+      // an aliased buffer with identical values and the aliasing reads as green.
+      let pass (seed: D) =
         let z = DM.Sum(ma .* ma)
-        z |> reverseProp D.One
+        z |> reverseProp seed
         ma |> adjoint
-      let g1 = pass ()
-      let g2 = pass ()
-      // d(sum(M .* M))/dM = 2M
+      let g1 = pass D.One
+      let g2 = pass (D 3.0)
+      // d(s * sum(M .* M))/dM = 2sM
       g1.[0, 0] |> Expect.dfloatClose "first pass [0,0], read after the second ran" accuracy 2.0
       g1.[1, 1] |> Expect.dfloatClose "first pass [1,1], read after the second ran" accuracy 8.0
-      g2.[0, 0] |> Expect.dfloatClose "second pass [0,0]" accuracy 2.0
-      g2.[1, 1] |> Expect.dfloatClose "second pass [1,1]" accuracy 8.0
+      g2.[0, 0] |> Expect.dfloatClose "second pass [0,0]" accuracy 6.0
+      g2.[1, 1] |> Expect.dfloatClose "second pass [1,1]" accuracy 24.0
 
     testCase "jacobianTv'' reverse evaluator keeps earlier seeds intact" <| fun _ ->
       // A strict special case of the first test, through the public DiffOps surface.


### PR DESCRIPTION
After #18 removed the reset cost, push was the entire remaining reverse-side
allocation: one fresh vector per adjoint contribution, 227,432 B/pass at depth
8 — 16.87 B per adjoint slot against an 8 B payload floor.

## The change

Two sites in `AD.Lite.fs`, the `DV` and `DM` central accumulates in `pushRec`:

```fsharp
dARef.Value <- DV.Add_V_V_Inplace(v, dARef.Value)   // was: dARef.Value + v
dARef.Value <- DM.Add_M_M_Inplace(v, dARef.Value)
```

The `*_Inplace` members were already in the file, dormant since the fork, and
pass the same `fd`/`df_*`/`r_*` lambdas as `(+)` — so every mixed nested-AD
case (`DVF`/`DVR`/`DMF`/`DMR` on either side) dispatches exactly as before, and
only the plain-into-plain case changes, to a destructive `daxpy` into the
buffer `reverseReset` leaves in place. They are destructive of their **second**
argument, hence `v` first. The scalar `D` accumulate (immutable) and the
sixteen direct `.A <-` sites are untouched.

No new failure modes: `Backend.Add_V_V` / `GenMat.addM` at the same site
already errored on the same shape mismatches — `addM` even required ColMajor on
*both* sides where in-place needs it only on the destination. The one narrowing
is an empty destination receiving a non-empty contribution, which a consistent
graph cannot produce while reset runs before every push; the interaction with
step 3 is recorded in the plan.

A second saving falls out for free: `Add_V_V`/`Mat.addM` return a **full copy**
of the non-empty side when the other side is empty, so every `DV.Zero` /
`DM.Zero` bookkeeping push (one per slicing-op consumption) was copying the
entire adjoint. Those are now no-ops.

## Results

`-- phases`, depth 8, B/pass:

| phase | before | after |
| --- | ---: | ---: |
| reset | 2,136 | 2,136 |
| push (derived) | 227,432 | **115,472** |
| push, per adjoint slot | 16.87 | **8.57** |
| reverseProp | 229,568 | **117,608** |

BenchmarkDotNet, depth 8 allocated:

| method | before | after |
| --- | ---: | ---: |
| Forward | 223.67 KB | 223.67 KB |
| ForwardAndReset | 225.76 KB (1.01x) | 225.76 KB (1.01x) |
| ForwardResetAndPush | 448.22 KB (2.00x) | **338.88 KB (1.52x)** |
| ForwardThenSeedPasses (x8) | 2017.53 KB (9.02x) | **1142.84 KB (5.11x)** |

`-- width` shows push converging on ~8 B per adjoint slot: each slot's value is
now allocated exactly once — the derivative payload itself (`dA .* b.P`, `-dA`,
…). Going below that means fusing derivative computation into the accumulate
(the structured-expression TODO already in the file), which is also why the
sixteen bypass sites were left: in this op mix they are inside the noise.

## The failure signature changed, and one test was blind to it

While push allocated, a broken `adjoint` copy made stale gradient reads come
back **zero**; with an in-place push they instead **alias the live buffer** —
and a same-seed rerun refills an aliased buffer with identical values, which
reads as green. The DM lifetime test seeded both passes with `D.One` and was
exactly that kind of blind; it now seeds its second pass with `D 3.0`. With
the copies in `adjoint` temporarily disabled, all three survival tests go red.

## Verification

- `dotnet test`: 16 + 11 + 35 passed, 6 skipped (the pre-existing `[<Ignore>]`).
- `npm test` (Fable→JS) and Fable→Python: 11 passing each.
- **Downstream, against `WldMr.Analytics` via the local folder feed:** all 445
  .NET and 222 Fable/JS tests pass. `BenchmarkMarketBuild -- fingerprint` is
  **byte-identical** to stock (`15a6fee3…`), stable across processes.
  `-- stages` at 20 reps: whole fit **79.8 → 74.0 MB**, all of it inside
  `fitMktData` (53.1 → 47.0 MB). Cumulative with #18: 86.6 → 74.0 MB, −14.6%.

## Scope

Remaining on the reverse side: the derivative payloads themselves and the
sixteen `.A <-` bypass sites. The eager buffer at construction (step 3) and the
reset-per-pass multiplier (step 5) are separate steps, sequenced in
`plans/ad-tape-allocation.md` — which this PR also condenses, replacing the
step-4 hand-over with the landed results.
