### PR TITLE
AD: seed adjoint refs with an empty sentinel, materialise on first reset

### DIFF
--- a/consoles/BenchmarkAdTape/Benchmarks.fs
+++ b/consoles/BenchmarkAdTape/Benchmarks.fs
@@ -24,9 +24,14 @@ open WldMr.Numerics.DiffSharp.AD.Float64
 /// - (a) forward             = `Forward`
 /// - (b) reset               = `ForwardAndReset` - `Forward`
 /// - (c) push                = `ForwardResetAndPush` - `ForwardAndReset`
-/// - (b)+(c) cross-check     = `ReversePassOnPrebuiltTape`, which should equal
-///   `ForwardResetAndPush` - `Forward`. If it does not, the subtraction is
-///   measuring something other than the phases.
+/// - (b)+(c) steady state    = `ReversePassOnPrebuiltTape`
+///
+/// Since adjoints became lazy (`DV.R` seeds every ref with the empty sentinel),
+/// the subtractions measure the *first* pass on a fresh tape, whose reset
+/// materialises every adjoint buffer — so `ForwardResetAndPush` - `Forward`
+/// exceeds `ReversePassOnPrebuiltTape` by exactly that materialisation cost
+/// (the old cross-check equality). The prebuilt tape was warmed by a full pass
+/// in `Setup`, so its row is the steady state, matching `-- phases`.
 ///
 /// There is deliberately no bare-reset benchmark on a prebuilt tape. It would be
 /// wrong: `resetRec` increments each node's fan-out counter and only recurses
@@ -66,9 +71,9 @@ type AdTapeBenchmark() =
 
   /// (a) alone: the forward evaluation that builds the tape, no reverse pass.
   ///
-  /// Not free of adjoint allocation — `DV.R` gives every node a fresh
-  /// `DV.ZeroN` at construction (`AD.Lite.fs:576`), so the zero vector a reset
-  /// later rewrites has already been allocated once, here.
+  /// Free of adjoint payload allocation since `DV.R` seeds each ref with the
+  /// shared empty sentinel; the full-length buffers are materialised by the
+  /// first reverse pass instead (`ForwardAndReset` pays them here).
   [<Benchmark(Baseline = true)>]
   member _.Forward() = Graph.forward fixture
 

--- a/consoles/BenchmarkAdTape/Phases.fs
+++ b/consoles/BenchmarkAdTape/Phases.fs
@@ -52,31 +52,37 @@ let census (spec: Graph.GraphSpec) =
   printfn "  gradient              length=%d  min=%.6g  max=%.6g"
     ga.Length (Array.min ga) (Array.max ga)
 
-/// One tape, three measurements: the forward pass, one full `reverseProp`, then
-/// one bare `reverseReset`.
+/// One tape, four measurements: the forward pass, the *first* `reverseProp`
+/// (which materialises the lazily-seeded adjoint buffers — `DV.R` starts every
+/// ref on the empty sentinel), a second steady-state `reverseProp` (buffers in
+/// place, reset reuses them), then one bare `reverseReset`.
 ///
 /// **The order is not arbitrary.** A tape is pushable only while every fan-out
-/// counter is zero, which holds when it is fresh and again after a complete push
-/// (`pushRec` decrements each counter back to 0). A bare `reverseReset` leaves
-/// the counters at each node's in-degree instead, and a *second* reset then
-/// finds them non-zero, declines to recurse (`AD.Lite.fs:3430`) and touches only
-/// the root — so a reset measured before the push would both mis-measure itself
-/// and silently disarm the push that followed. Hence: forward, push, reset,
-/// throw the tape away.
+/// counter is zero, which holds when it is fresh and again after each complete
+/// push (`pushRec` decrements each counter back to 0) — so both pushes are
+/// legal, and the trailing bare reset measures steady state because the pushes
+/// before it materialised every buffer. A bare `reverseReset` leaves the
+/// counters at each node's in-degree instead, and a *second* reset then finds
+/// them non-zero, declines to recurse (`AD.Lite.fs:3430`) and touches only the
+/// root — so a reset measured before the pushes would both mis-measure itself
+/// and silently disarm the push that followed. Hence: forward, push, push,
+/// reset, throw the tape away.
 let private measureOnce (fx: Graph.Fixture) =
   let a0 = alloc ()
   let root, x = Graph.forward fx
   let a1 = alloc ()
   push root
   let a2 = alloc ()
+  push root
+  let a3 = alloc ()
   // Checked here, between the push and the reset: the gradient is live only in
   // this window, since the bare reset below is about to erase it. Its own
   // allocation is excluded by restarting the counter afterwards.
   guard root (x |> adjoint)
-  let a3 = alloc ()
-  reset root
   let a4 = alloc ()
-  a1 - a0, a2 - a1, a4 - a3
+  reset root
+  let a5 = alloc ()
+  a1 - a0, a2 - a1, a3 - a2, a5 - a4
 
 /// Allocated bytes for (a) the forward evaluation that builds the tape,
 /// (b) the reset, and (c) the push — with (c) derived, not measured.
@@ -86,23 +92,30 @@ let private measureOnce (fx: Graph.Fixture) =
 /// (`AD.Lite.fs:3648`) and `reverseProp` calls `reverseReset` before it
 /// (`AD.Lite.fs:3997`), so the only public push includes a reset. (c) is
 /// therefore `reverseProp` minus the bare reset, and is labelled derived.
+///
+/// (b) and (c) are steady state. The first `reverseProp` on a fresh tape
+/// additionally materialises the lazy adjoint buffers (`DV.R` seeds every ref
+/// with the empty sentinel) and is reported as its own row — deriving push
+/// from it would wrongly charge the materialisation to the push.
 let phases (spec: Graph.GraphSpec) (reps: int) =
   let fx = Graph.build spec
   measureOnce fx |> ignore // warm: JIT, the DiffSharp statics, the tagger
 
   let mutable fwd = 0L
+  let mutable fp = 0L
   let mutable rp = 0L
   let mutable rst = 0L
   let sw = Stopwatch.StartNew()
   for _ in 1 .. reps do
-    let f, p, r = measureOnce fx
+    let f, p1, p, r = measureOnce fx
     fwd <- fwd + f
+    fp <- fp + p1
     rp <- rp + p
     rst <- rst + r
   sw.Stop()
 
   let n = float reps
-  let fwd, rp, rst = float fwd / n, float rp / n, float rst / n
+  let fwd, fp, rp, rst = float fwd / n, float fp / n, float rp / n, float rst / n
   let nodes = float (Graph.nodeCount spec)
   let slots = Graph.adjointSlots spec
   let floorBytes = float slots * 8.0
@@ -114,8 +127,9 @@ let phases (spec: Graph.GraphSpec) (reps: int) =
     printfn "  %-28s %12.0f %12.1f %12.2f" label bytes (bytes / nodes) (bytes / float slots)
   row "(a) forward, builds tape" fwd
   row "(b) reset      [measured]" rst
-  row "(a)+(b)+(c) reverseProp" rp
+  row "(b)+(c) reverseProp, steady" rp
   row "(c) push       [derived]" (rp - rst)
+  row "first pass (materialises)" fp
   printfn "  ---"
   printfn "  zero-vector floor         %12.0f B  (%d slots x 8 B)" floorBytes slots
   printfn "  reset / floor             %12.2f x" (rst / floorBytes)
@@ -138,7 +152,7 @@ let sweep (varying: string) (label: Graph.GraphSpec -> string) (specs: Graph.Gra
     let mutable rp = 0L
     let mutable rst = 0L
     for _ in 1 .. reps do
-      let f, p, r = measureOnce fx
+      let f, _, p, r = measureOnce fx
       fwd <- fwd + f
       rp <- rp + p
       rst <- rst + r
@@ -194,24 +208,30 @@ let seedPasses (spec: Graph.GraphSpec) (reps: int) =
   guard warmRoot (warmX |> adjoint)
 
   let mutable fwd = 0L
-  let mutable passes = 0L
+  let mutable first = 0L
+  let mutable rest = 0L
   for _ in 1 .. reps do
     let a0 = alloc ()
     let root, x = Graph.forward fx
     let a1 = alloc ()
-    for _ in 1 .. Graph.SeedPasses do
-      push root
+    // Pass 1 materialises the lazily-seeded adjoint buffers; the rest reuse them.
+    push root
     let a2 = alloc ()
+    for _ in 2 .. Graph.SeedPasses do
+      push root
+    let a3 = alloc ()
     guard root (x |> adjoint)
     fwd <- fwd + (a1 - a0)
-    passes <- passes + (a2 - a1)
+    first <- first + (a2 - a1)
+    rest <- rest + (a3 - a2)
 
   let n = float reps
-  let fwd, passes = float fwd / n, float passes / n
+  let fwd, first, rest = float fwd / n, float first / n, float rest / n
   printfn "seeds   depth=%d, %d reverse passes over one tape, %d reps"
     spec.Depth Graph.SeedPasses reps
   printfn "  forward (once)            %12.0f B" fwd
-  printfn "  %d reverse passes          %12.0f B  (%.0f B each)"
-    Graph.SeedPasses passes (passes / float Graph.SeedPasses)
+  printfn "  first pass (materialises) %12.0f B" first
+  printfn "  %d further passes          %12.0f B  (%.0f B each)"
+    (Graph.SeedPasses - 1) rest (rest / float (Graph.SeedPasses - 1))
   printfn "  total                     %12.0f B  (%.1f%% of it reverse)"
-    (fwd + passes) (100.0 * passes / (fwd + passes))
+    (fwd + first + rest) (100.0 * (first + rest) / (fwd + first + rest))

--- a/plans/ad-allocation-redesign.md
+++ b/plans/ad-allocation-redesign.md
@@ -1,0 +1,153 @@
+# Reducing per-op AD allocation: direction note
+
+**Status: direction-setting, 2026-08-07.** Follows `ad-tape-allocation.md`, whose
+steps 2 and 4 (buffer reuse on reset, `d1f4435`; in-place accumulation on push,
+`1af3889`) are landed. After those, the AD/LinAlg cluster is still roughly half
+of an Analytics `MarketBuild` fit's allocation: in a 20-fit trace, `Double[]`
+alone is 414.7 MB (31.6%), led by `CsrMat.mulV` (76.7 MB), `DV.op_DotMultiply`
+(74.3 MB) and `DV.ZeroN` (32.0 MB), plus ~140 MB of `D`/`DV` wrappers, ~78 MB of
+worklist tuples and cons cells, and 16.6 MB of `FSharpRef<uint32>` fan-out
+counters. The remaining cost is structural — every eager op allocates — so this
+note sets direction rather than designing a fix.
+
+## Where the bytes go per op
+
+Trace `a .* b` on two same-tag `DVR`s (`AD.Lite.fs:944`, dispatched through
+`Op_DV_DV_DV`, DVR×DVR case `:748`). The forward op allocates **seven objects**:
+the result `float[]` (`Backend.Map2_Mul_V_V`, `Backend.Lite.fs:401`) and its `DV`
+wrapper; then `DV.R` (`AD.Lite.fs:576`) adds a full-length zero adjoint `float[]`
+(`DV.ZeroN`, `:648`) with its own `DV` wrapper, a `ref` cell for it, a `ref 0u`
+fan-out cell, and the `DVR` node itself — plus the `Mul_Had_DV_DV(a, b)` TraceOp
+object (`:2736`). Each reverse pass then adds, per node: cons cells in reset
+(`:3473`), a `(dobj*dobj)` tuple plus cons cell per contribution in push
+(`:3685`), and one derivative-payload array per slot (`dA .* b.P`, `:3806` — the
+one array 1af3889 left, since the accumulate itself is now in place, `:3787`).
+The tape pins every buffer until reset, so nothing is reclaimed mid-fit. Sparse
+matvec pays the same twice over: `CsrMat` `MulV` allocates its result
+(`CsrMat.fs:70`) once per layer forward and once per layer per reverse pass
+(`Mul_DMCons_DV` push, `AD.Lite.fs:3813`, via `GenMat.mulV`, `GenMat.fs:136`).
+
+## Candidate directions
+
+**a. Buffer pooling / arena tied to the tape lifecycle.** Rent result and
+adjoint arrays from a pool owned by the tape generation; return them wholesale.
+Payoff ceiling is the largest — it covers the result arrays that dominate
+`Double[]` — but there is no lifecycle hook to anchor it: the "tape" is the
+implicit graph hanging off `DVR` nodes, and the only sweep points are
+reverse-reset (`:3372`, which runs over a still-live graph, many times per tape
+in `CurveSolver.ff'`) and GC. Recycling therefore needs an explicit tape-scope
+API, a new public surface. The specific sinking risk is aliasing with
+caller-held arrays: `DV.toFloats` (`:650`) hands out the backing array, and
+primals escape through far more paths than adjoints ever did. The
+`adjoint`-copies precedent (`:3352`) bounds the shape of the fix — copy at every
+escape accessor, enumerated by audit, exactly as step 1 did for adjoints — but
+the primal escape surface is much wider, so the audit is the real cost.
+Reorder-free (same values, recycled storage). **Weeks.**
+
+**b. In-place ops via fan-out (refcount-guided reuse of an input buffer).**
+Mostly not viable at construction time: fan-out counters are populated during
+*reset* (`:3456`), not during the forward pass, so an op cannot know its
+operand is dead — and even a dead-looking operand's primal is retained by the
+TraceOp precisely because push needs it (`Mul_Had_DV_DV` push reads `a.P` and
+`b.P`, `:3806`). Overwriting an input corrupts the recorded primal. The viable
+narrow form is push-side: the contribution temporaries (`dA .* b.P` etc.) are
+uniquely owned by `pushRec` and die within the pass — but that is a pooling
+problem with a clean lifecycle, i.e. a sub-case of (a), not a separate
+direction. **Days for the narrow form (as part of a); weeks and fragile for the
+general form — do not pursue the general form.**
+
+**c. Fusing the hot patterns.** Two flavours. *Forward fusion*: new ops for the
+axpy-like chains the curve code produces (e.g. `exp`∘`.*`, `.*`-then-`+`), each
+replacing 2–3 nodes with one — one result array, one TraceOp, one `DVR`, one
+zero adjoint instead of two or three of each. This is the only lever that
+reduces *node count*, which is what the ~140 MB of wrappers, ~78 MB of
+tuples/cons and 16.6 MB of refs all scale with. Cost: each fused op needs
+forward-dual, reset and push cases (FS0025 exhaustive matching helps), and
+consumer adoption in Analytics' curve code — a cross-repo change. *Push-site
+fusion*: compute the contribution directly into the child's adjoint buffer
+instead of materialising it — e.g. the sparse `Transpose(cons) * dA` temp at
+`:3813` folded into the accumulate (a sparse variant of the dense-only
+`Backend.Mul_M_V_Add_V'`, `Backend.Lite.fs:219`, which today also copies). This
+is the structured-contribution worklist flagged at the end of
+`ad-tape-allocation.md` — the only way below the current ~8 B/slot push floor.
+Fingerprint: fusion is reorder-free **only if** the fused kernel performs the
+identical scalar operations in the identical per-element order — no FMA, no
+reassociation, no `dgemv` `beta`-accumulation reordering. That is achievable
+(element-wise chains and CSR row loops have a natural order) but must be
+verified per kernel with Analytics' `-- fingerprint`. **Days per fused op
+family; the structured worklist is weeks.**
+
+**d. `DV.R`'s eager zero vector → lazy.** The known open item (step 3 of
+`ad-tape-allocation.md`): `:576` allocates a full-length zero adjoint at node
+construction, 32.0 MB in the trace, and reset re-zeroes or replaces it anyway.
+Initialise the ref with the empty `DV.Zero` sentinel (`:646`) instead; reset's
+existing fallback arm (`:3455`) already materialises full-length on the shape
+mismatch, so the 1af3889 invariant — "buffers are full-length by push time,
+because reset runs before every push" (`:4040`) — holds without new code at the
+push site. `Add_V_V_Inplace`'s empty-destination error path (`Backend.Lite.fs:34`)
+stays unreachable; add a test asserting exactly that invariant, plus the
+nested-AD (`DVF` adjoint) case. Do **not** go further and have push install the
+first contribution directly without a zero fill: contributions like `bxv dA a`
+alias the parent's own adjoint buffer, and installing one uncopied aliases two
+nodes' adjoints. Reorder-free. **Hours, plus the usual tri-target test and
+local-feed verification day.**
+
+**Done 2026-08-07 (in-tree, with invariant tests; both `DV.R` and `DM.R`, via
+shared empty sentinels).** Measured: in-repo forward B/pass halves (229,040 →
+118,464 at depth 8) and the materialisation moves to the tape's *first* reverse
+pass — the multi-seed total is byte-identical, so a fully-visited tape nets
+zero, exactly as the ad-tape plan's step-4 section predicted. Downstream the
+effect on MarketBuild is **nil today** (54.7 MB whole-fit with and without,
+A/B'd on the same Analytics commit): the z-spread-on-floats work had already
+removed the forward-only tapes this would have saved. Two corrections to the
+paragraph above: the `DV.ZeroN` trace line does not vanish — `ZeroN` inlines
+into its callers, and for visited nodes the allocation reappears under
+`resetRec`'s fallback arm — and the payoff is best understood as hardening:
+any consumer path that evaluates reverse-typed values without differentiating
+stops paying for adjoints it never uses, which is precisely the population the
+Analytics bond work was eliminating by hand.
+
+**e. Not worth pursuing now.**
+- *Full lazy expression-graph rewrite* — months, destroys diffability against
+  upstream DiffSharp, and every consumer inherits the fingerprint risk at once.
+- *Span/stackalloc/ArrayPool/SIMD widening* — the arrays here escape into the
+  tape, so stack lifetimes don't fit; `ArrayPool` isn't available under
+  Fable→JS/Python (the tri-target guard pattern, `CsrMat.fs:45-50`, covers small
+  divergences, not a pooling substrate — that substrate is option (a), written
+  portably).
+- *Struct `D` / merging `DVR`'s two ref cells into one state object* — the refs
+  are ~1% of the trace; a struct DU can't be recursive, and the merge rewrites
+  every `DVR(...)` pattern in a 4,200-line forked file for a marginal win.
+
+## Sequencing
+
+1. ~~**(d) first.**~~ **Done 2026-08-07** — see the outcome note under (d):
+   in-repo forward halves, downstream currently nil (Analytics' bond work got
+   there first), `-- fingerprint` unchanged, all 445 + 222 downstream tests
+   green against the local feed.
+2. **(c), forward-fusion flavour, for the top two chains** in the MarketBuild
+   profile (the CSR-matvec → `.*` → `exp` layer). Justified if, after (d), the
+   trace still shows wrappers + tuples/cons (~220 MB combined) scaling with node
+   count — they will. Gate each fused op on a byte-identical fingerprint before
+   adoption.
+3. **(a) only if still needed after fusion**, starting with the narrow push-temp
+   pool (which subsumes the useful part of (b)), then the full arena behind an
+   explicit tape scope — preceded by the primal-escape audit, run exactly like
+   step 1's adjoint audit.
+4. The structured-contribution worklist (deep flavour of (c)) stays parked until
+   the cheap levers are exhausted; re-evaluate against whatever the trace then
+   shows.
+
+Reorder-free and fingerprint-safe by construction: (a), (b), (d). Requires
+per-kernel fingerprint proof: (c), both flavours.
+
+## Effort
+
+| option | class |
+| --- | --- |
+| d. lazy `DV.R` adjoint | hours (+ a day of tri-target and downstream verification) |
+| c. forward fusion, per op family | days |
+| a. push-temp pool | days |
+| a. full arena + tape scope + primal audit | weeks |
+| c. structured contribution worklist | weeks |
+| b. general refcount-guided in-place | not recommended |

--- a/plans/ad-gather.md
+++ b/plans/ad-gather.md
@@ -1,0 +1,422 @@
+# A first-class reverse-mode `gather` for `DV`
+
+**Status: design, 2026-08-07. Nothing implemented. Written against master at
+`1af3889` ("accumulate adjoints in place on reverse push").**
+
+Line references are against that commit. `AD.Lite.fs` means
+`src/WldMr.Numerics.DiffSharp/AD.Lite.fs` (4,224 lines) unless said otherwise.
+
+## Why
+
+`WldMr.Analytics`' `LinearInterpolator.InterpolateV`
+(`src/WldMr.Analytics/Curve/LinearInterpolation.fs:80-104`) needs, per call:
+
+```
+result[i] = c0[ks[i]] + (ts[i] - x[ks[i]]) * c1[ks[i]]
+```
+
+with `ks: int[]` segment indices, `x: float[]` constants, `c0, c1 : DV` on the
+reverse tape. Because no differentiable gather exists, it builds **two** CSR
+selection matrices per call — `csrS` (:82-86: an all-ones values array, `ks` as
+columns, an `n+1` row-index array) and a hand-built transpose `csrST` (:88-97:
+another ones array, an `n` rows array, an `m+1` column-index scan) — wraps them
+as `DM (SparseDouble (csrS, csrST))` (:99) and runs two sparse mat-vec products
+(:102-103). `csrST` exists **only** so that `GenMat.transpose`
+(`src/WldMr.Numerics.LinAlg/GenMat.fs:97`, a pair swap) is free when the
+reverse pass of `Mul_DMCons_DV` computes `DM.Transpose(cons) * dA`
+(`AD.Lite.fs:3813`) — i.e. it is the reverse rule, precomputed by hand on every
+forward call.
+
+Measured cost, from the MarketBuild CPU/allocation profile
+(`WldMr.Analytics/plans/marketbuild-cost.md:753-769`): **~5.5 MB/fit**, with
+49.6 MB of `Double[]` attributed to `InterpolateV` across a 20-fit trace, plus
+the `Int32[]` index arrays, the `SparseDouble`/`DM` wrappers, and
+`CsrMat.mulV` cost downstream (76.7 MB of `Double[]` across all callers). It
+runs per pricing evaluation inside the curve-fit solver loop.
+
+A gather primitive — forward: pick elements by index; reverse: scatter-add the
+incoming adjoint into the source's adjoint — collapses the whole ceremony to
+one captured index array.
+
+## 1. API surface
+
+Repo convention for `DV` ops is tupled static members, data first:
+`DV.AddSubVector (a, i, b)` (:1164), `DV.Split (d, n)` (:685),
+`DV.Append (a, b)` (:1377). Follow it:
+
+```fsharp
+/// result.[i] = a.[ks.[i]]
+static member Gather (a: DV, ks: int[]) : DV
+
+/// The adjoint pair: length-n vector with result.[ks.[i]] accumulating b.[i]
+static member Scatter (b: DV, ks: int[], n: int) : DV
+```
+
+plus a pipe-friendly helper in `module DV` (:2924), matching `DV.ofArray` /
+`DV.toArray` style: `let inline gather (ks: int[]) (v: DV) = DV.Gather(v, ks)`.
+(The prompt's curried `int[] -> DV -> DV` shape is what the module helper
+provides; the static member follows the file's existing tupled form.)
+
+`Scatter` is public because it is `Gather`'s reverse rule and the two are each
+other's adjoints — exactly the pairing `Slice_DV` / `AddSubVector` already
+have (push at :3893-3895 calls `DV.AddSubVector`). It must be a first-class op
+anyway for nested AD (see §2), so hiding it buys nothing.
+
+**Single-index `D` variant: do not add one.** It already exists as the indexer
+`d.[i]` (:584-589), trace op `Item_DV` (:2713), push at :3741-3743.
+
+**Bounds validation: always on, in both debug and release, on all three
+targets.** The check is one integer compare per element against arithmetic
+that then does O(n) double work — noise. And it is not optional off .NET:
+under Fable→JS a `Float64Array` read out of bounds yields `undefined` (NaN
+after arithmetic) and an out-of-bounds *write is silently discarded*; under
+Fable→Python a negative index silently wraps to the end of the array. Only
+.NET throws. Validate `0 <= ks.[i] < a.Length` in `DV.Gather` (and `< n`,
+plus `ks.Length = b.Length`, in `DV.Scatter`) with an `invalidArg` following
+the `ErrorMessages` pattern (`DiffSharp/Util.fs:107-110`). Empty `ks` returns
+`DV.Zero` (:646) without building a node, matching `Append`'s empty-operand
+early-outs (:1378-1381).
+
+The index array is captured **without copying**, like `csrS.Columns = ks`
+aliases it today (`LinearInterpolation.fs:84`); document that the caller must
+not mutate `ks` after the call, and that the tape keeps it alive until the
+tape dies (against six arrays today — a net reduction).
+
+## 2. Tape representation, forward, reverse
+
+### Trace ops
+
+Two new cases in `TraceOp` (:2669), in the vector-valued section next to
+`Slice_DV` (:2810):
+
+```fsharp
+| Gather_DV               of DV * int[]     // source node, indices
+| Scatter_DV              of DV * int[]     // source node, indices
+```
+
+`Gather_DV` captures the source `DV` (the node reference the walkers recurse
+into, as every case does) and the index array. Only one case each: the index
+array is a constant, so there is no `*Cons` triplet as for two-`D`-argument
+ops.
+
+### Forward
+
+Both are unary linear ops and fit `Op_DV_DV` (:700-704) exactly, the same
+mould as `DV.Sum`/`ReshapeToDM` (:1369, :1393):
+
+```fsharp
+static member Gather (a: DV, ks: int[]) =
+    // validate ks against a.Length here (always)
+    let inline ff(a) = Backend.Gather_V(a, ks)
+    let inline fd(a) = DV.Gather(a, ks)
+    let inline df(cp, ap, at) = DV.Gather(at, ks)      // linear: tangent gathers
+    let inline r(a) = Gather_DV(a, ks)
+    DV.Op_DV_DV (a, ff, fd, df, r)
+```
+
+`Scatter` is symmetric (`ff = Backend.Scatter_V(b, ks, n)`,
+`df = DV.Scatter(bt, ks, n)`, `r = Scatter_DV(b, ks)`).
+
+The array kernels go in `Backend.Lite.fs` per this repo's rule ("numeric
+behaviour changes belong here, not in `AD.Lite.fs`" — `CLAUDE.md`), alongside
+`Sum_V`/`Add_V_V`:
+
+```fsharp
+static member inline Gather_V(x: float[], ks: int[]) =
+    let r = Array.zeroCreate ks.Length
+    for i in 0 .. ks.Length - 1 do r.[i] <- x.[ks.[i]]
+    r
+static member inline Scatter_V(x: float[], ks: int[], n: int) =
+    let r = Array.zeroCreate n
+    for i in 0 .. ks.Length - 1 do
+        let k = ks.[i]
+        r.[k] <- r.[k] + x.[i]           // duplicates ADD; ascending i — see §7-adjacent bit-identity note
+    r
+```
+
+The DVR branch of `Op_DV_DV` builds the node via `DV.R` (:576), which still
+allocates the eager `DV.ZeroN` adjoint — same as every op; that is
+`ad-tape-allocation.md` step 3's business, not this op's.
+
+### Reverse
+
+`resetRec`, in the `DVR` branch's op dispatch (the list at :3459-3547):
+
+```fsharp
+| Gather_DV(a, _)  -> resetRec (bxd a :: t)
+| Scatter_DV(b, _) -> resetRec (bxd b :: t)
+```
+
+`pushRec`, in the `DV` branch (:3792-3900):
+
+```fsharp
+| Gather_DV(a, ks)  -> pushRec ((bxv (DV.Scatter(dA, ks, a.Length)) a) :: t)
+| Scatter_DV(b, ks) -> pushRec ((bxv (DV.Gather(dA, ks)) b) :: t)
+```
+
+Design choice, deliberate: **materialize the scatter vector and push it
+through the central channel** — the style of `AddSubVector_DV_DV`'s push
+(:3889) — rather than the `.A <-` bypass style of `Slice_DV` (:3893-3895,
+`a.A <- DV.AddSubVector(a.A, i, dA)` followed by an identity `bxv DV.Zero a`
+push). Reasons:
+
+- **It composes with `1af3889` for free.** The central accumulate
+  (:3782-3788) does `dARef.Value <- DV.Add_V_V_Inplace(v, dARef.Value)` — a
+  destructive `daxpy` into the buffer `reverseReset` leaves in place when both
+  sides are plain `DV`, with the `(+)` dispatch for every nested case
+  (`DV.Add_V_V_Inplace` :906-915, `Backend.Add_V_V_Inplace`
+  `Backend.Lite.fs:34-40`). A pushed contribution is only ever read, which is
+  precisely the ownership contract the step-4 commit message establishes for
+  central-channel pushes. No new `.A` bypass site is added to the sixteen the
+  audit counted.
+- **Fan-out stays textbook.** `resetRec` bumps the source's counter once per
+  gather node (:3456-3457); `pushRec` decrements once and delivers exactly one
+  contribution (:3782). If one source feeds two gathers, the counter reaches 2
+  and the source's own parents are visited only after both contributions have
+  arrived — the protocol from `ad-tape-allocation.md` constraint 2, untouched.
+  **Duplicate indices inside one `ks` are internal to the node**: they fold
+  inside `Scatter_V`'s `+=`, and contribute nothing extra to fan-out. That is
+  the correct accounting — one op, one use.
+- **Nested AD works without special cases.** Under forward-on-reverse the
+  incoming `dA` can be a `DVF` (constraint 5 in `ad-tape-allocation.md`);
+  `DV.Scatter` is itself a proper op, so the `DVF` dispatches through
+  `Op_DV_DV`'s middle branch and produces the right dual — the same reason
+  `Slice_DV`'s push calls the differentiable `DV.AddSubVector` rather than an
+  array loop. This is also why `Scatter_DV` needs its own reset/push cases
+  (reverse-on-reverse puts scatter nodes on an outer tape).
+- **Allocation is a wash versus the bypass.** The bypass would call an
+  `AddScatter`-style op whose `ff` copies the whole adjoint
+  (`Array.copyFast`, as `AddSubVector`'s `ff` does at :1165-1169); the
+  materialized vector is the same one full-length `float[]` — and it is
+  byte-for-byte the vector the CSR path already allocates as
+  `DM.Transpose(cons) * dA`. A later zero-allocation variant (guarded in-place
+  scatter into `a.A`) is possible but changes summation order — see §7; do not
+  do it in the first cut.
+
+Also note the empty-adjoint invariant: the contribution flows through the same
+channel as every other op, so the step-3 interaction documented in
+`ad-tape-allocation.md` ("an empty destination receiving a non-empty
+contribution is `Add_V_V_Inplace`'s error path; reset runs before every push,
+so buffers are full-length by push time") applies to gather unchanged, with
+nothing new to mind.
+
+**Implementation trap, worth stating:** both walkers end every branch with a
+wildcard (`| _ -> resetRec t` at :3436/:3551, `| _ -> pushRec t` at :3901).
+`src/Directory.Build.props`' `WarningsAsErrors FS0025` does **not** protect a
+new `TraceOp` case — forgetting the `pushRec` case compiles clean and yields a
+silent zero gradient; forgetting `resetRec` leaves the source un-reset and
+un-armed. The §4 tests are chosen to catch exactly these two failure shapes.
+
+## 3. The consumer rewrite
+
+`InterpolateV` (`LinearInterpolation.fs:80-104`) becomes:
+
+```fsharp
+member li.InterpolateV (ts: float[]): DV =
+  let ks = li.LeftSegmentIndex(ts)
+  let vX = Array.init ts.Length (fun i -> x.[ks.[i]])   // x is constant — plain float loop, no AD
+  let dTs_minus_X = Blas.sub_V_V(ts, vX)
+  let a = DV.Gather(c0, ks)
+  let b = DV.Gather(c1, ks) .* (DV dTs_minus_X)
+  DV.Add_V_V_Inplace(a, b)
+```
+
+Expression topology is 1:1 with today's (`Gather_DV` replaces each
+`Mul_DMCons_DV`; the `.*` node and the final `Add_V_V_Inplace` node are
+unchanged), which matters for §7.
+
+Gone per call (n = `ts.Length`, m = `x.Length`):
+
+- `csrS`: the ones array (n doubles) and `RowIndices` (n+1 ints) — `Columns`
+  aliased `ks` and cost nothing;
+- `csrST` entirely: ones (n doubles), rows (n ints), colIndices (m+1 ints),
+  plus the O(m+n) scan loop that builds it (:92-96);
+- the `SparseDouble` `GenMat` case and the `DM` wrapper (:99), and their
+  lifetime on the tape — the two `Mul_DMCons_DV` trace nodes each held the
+  whole six-array structure alive until the tape dropped; `Gather_DV` holds
+  one `int[]`;
+- two `CsrMat.mulV` runs (n multiply-adds each, `CsrMat.fs:119-130`) become
+  two n-element copy loops; `vX`'s mulV (:100) becomes the plain loop above.
+
+Stays: `ks`, `vX`, `dTs_minus_X` (same three arrays as today), the two gather
+result vectors (the mat-vec products allocated the same), the two `DVR` nodes
+with their eager adjoints, and — on the reverse side — one materialized
+length-m vector per gather per pass, same as `csrST * dA` costs today.
+
+Side benefit: the CSR-transpose construction (:92-96) silently requires `ks`
+non-decreasing (and `LeftSegmentIndex(ts)` at :48-62 requires `ts` sorted).
+Gather itself has no ordering requirement, so this rewrite removes one of the
+two hidden sortedness assumptions.
+
+## 4. Correctness testing
+
+Layout per `CLAUDE.md`: `tests/ExpectoTests` is the only Fable-compiled suite
+(new lists register in `all`, `Main.fs:15-21`; the file is added to the
+explicit `<Compile>` list); `tests/WldMr.Numerics.DiffSharp.Checks` is the
+.NET FsCheck net (`[<Property>]` style, `AD.Float64.fs:14`).
+
+**`tests/ExpectoTests/GatherTests.fs`** — cross-runtime, deterministic values
+(gather is exact index-picking, so integer-valued expectations through
+`Expect.floatClose` with the existing `accuracy`, per
+`AdjointLifetimeTests.fs:22`):
+
+1. Forward values, including duplicate and *unsorted* `ks`.
+2. Reverse with duplicates: `f v = DV.Sum(DV.Gather(v, [|1;1;0|]))` on
+   `makeReverse`'d input; gradient must be `[|1.; 2.|]` — **the scatter must
+   ADD**. This is also the test that goes red if the `pushRec` case is
+   forgotten (silent zero) or if a future in-place variant overwrites instead
+   of accumulating.
+3. Fan-out: one source feeding **two** gather nodes combined by `+`; the
+   gradient is the sum of both scatters. Red if the `resetRec` case is
+   forgotten (the counter never arms; stale adjoints or a stopped push).
+4. Nested: forward-over-reverse through a gather (a `DVF`-seeded pass, the
+   constraint-5 shape), exercising `Scatter`'s `DVF` dispatch.
+5. Bounds: index `= a.Length` **and** index `= -1` both raise, asserted on
+   all three runtimes — the JS-silent/Python-wrap trap from §1 is exactly why
+   this test must run under Fable, not only .NET.
+
+**`tests/WldMr.Numerics.DiffSharp.Checks`** (new `[<Property>]`s next to
+`AD.Float64.fs`):
+
+6. Finite differences: `grad (fun v -> DV.Sum(DV.Gather(v, ks) .* w))` versus
+   `Numerical.Float64` `DiffOps.grad'` (`Numerical.Float64.fs:51-59`) via
+   `Util.(=~)`, over random `v`, random weights, `ks` mapped into range by
+   `abs k % v.Length`. Linearity means a weighted-sum probe covers the whole
+   Jacobian.
+7. CSR equivalence, the adoption guard in miniature: build the exact
+   `InterpolateV` pair of formulations (selection CSR + `SparseDouble`/`DM`
+   versus gather) over random sorted inputs; assert primal **and**
+   reverse-mode gradients equal with `=`, **not** `=~` — this is the in-repo
+   canary for the §7 bit-identity claim. (Generator must produce
+   non-decreasing `ks`; the CSR-transpose construction requires it, gather
+   does not.)
+
+Also run the adjoint-lifetime suite unchanged — gather goes through `adjoint`
+(:3352-3365) like everything else, and its copy contract is what makes the
+consumer's hoisted-`makeReverse` loop safe.
+
+## 5. Benchmark
+
+`consoles/BenchmarkAdTape` gains one BDN class and one phases mode; the
+existing `AdTapeBenchmark` rows stay untouched for cross-run comparability.
+
+- `Benchmarks.fs`: `[<MemoryDiagnoser>] type GatherBenchmark` over the
+  `InterpolateV` shape at the harness's standard width (m=40 pillars, n=320
+  points, `Graph.spec`'s ratio; sorted synthetic `ts`, `c0`/`c1`
+  `makeReverse`'d per iteration like `Graph.forward`). Four rows:
+  `CsrForward`, `GatherForward`, `CsrForwardAndReverse`,
+  `GatherForwardAndReverse`. Read `Allocated`, as the file header says.
+- `Phases.fs`/`Program.fs`: a `-- gather [reps]` mode printing forward/reverse
+  B/pass for both formulations from `GC.GetTotalAllocatedBytes`, and
+  asserting value and gradient max-abs-diff is exactly `0.0` — a standing
+  bit-parity check that runs in seconds, unlike the BDN suite.
+
+Expected shape of the result: forward-side saving ≈ the six CSR arrays and
+wrappers (~2n doubles + (2n+m+2) ints ≈ 6.5 KB per call at n=320) plus the
+mulV arithmetic; reverse side ≈ unchanged (the materialized scatter vector
+replaces `csrST * dA` one-for-one). The end-to-end number that matters is
+downstream: `WldMr.Analytics`' `BenchmarkMarketBuild -- stages 20`
+(`fitMktData` column; 47.0 MB is the current post-`1af3889` baseline per
+`ad-tape-allocation.md`) via the local feed.
+
+## 6. Fable notes
+
+- **No BCL guards needed.** Both kernels are index loops plus
+  `Array.zeroCreate`; the `System.Array.Clear` guard precedent
+  (`LinAlg/CsrMat.fs:45-50`) was checked and is not required — nothing
+  platform-specific appears.
+- **The bounds check is a correctness feature under Fable, not hygiene** —
+  JS typed arrays don't throw and Python wraps negatives (§1). This is the
+  one place the three targets genuinely diverge.
+- `int[]` compiles to `Int32Array` (JS); capturing it in a union case is fine.
+- New test file goes into `ExpectoTests.fsproj`'s explicit `<Compile>` list in
+  dependency order; new members in `AD.Lite.fs` keep the fork's 4-space
+  indentation (repo `CLAUDE.md`: do not reformat forked files).
+- The Python target is not in CI — run
+  `dotnet fable tests/ExpectoTests --lang python -o py-build/tests/ExpectoTests
+  && python3 py-build/tests/ExpectoTests/main.py` by hand; the bounds test (5)
+  is the one that can only fail there.
+
+## 7. Versioning, rollout, and the fingerprint
+
+**Version:** the package version is CI-composed — `major: 1` / `minor: 3`
+with a patch counter keyed on `major.minor`
+(`azure-pipelines.yml:13-24,35`) — so merging to master publishes **1.3.16**
+with no file edit. Recommended over bumping to 1.4.0: the change is purely
+additive, and `17e9147` ("Constrain dependencies so consumers can adopt
+1.3.x") deliberately set consumers up for the 1.3 line. Analytics resolves
+with `lowest_matching` and currently pins/locks `>= 1.3.15`
+(`WldMr.Analytics/paket.dependencies:55-56`, `paket.lock:284-289`), so it
+moves only via an explicit bump to `>= 1.3.16` in the same PR as the
+`InterpolateV` rewrite. Pre-merge validation via
+`local-feed.sh` / the `-pr` packages (`wldmr-cross-repo-dev` skill), release
+via `wldmr-analytics-release`.
+
+**The fingerprint must not move:**
+`BenchmarkMarketBuild -- fingerprint` must stay
+`15a6fee33a346e31be9e6de14de49e968ea71958bdd5193885939d9d2c0cf52d`
+(`ad-tape-allocation.md`, verification recipe). The claim: **the gather
+formulation is bit-identical to the CSR formulation**, on three grounds, each
+checked against the code:
+
+1. *Forward.* `CsrMat.mulV` (`CsrMat.fs:119-130`) computes a one-entry row as
+   `0.0 + c0[k] * 1.0`. `x * 1.0 = x` exactly and `0.0 + x = x` exactly for
+   every double **except `x = -0.0`** (which normalizes to `+0.0`); gather
+   returns `c0[k]` verbatim. So the primals agree bitwise unless an
+   interpolated coefficient is exactly negative zero — unreachable from the
+   exp/division arithmetic these curves are made of, but it is the one stated
+   exception rather than a proof of full equality.
+2. *Reverse.* The CSR reverse contribution is `csrST * dA`: for source `j`,
+   `mulV` left-folds `dA[i]` over `csrST`'s row-`j` entries, which the
+   construction at `LinearInterpolation.fs:88-97` lists in ascending `i` (it
+   requires `ks` non-decreasing). `Scatter_V` iterates `i` ascending into a
+   zero-initialized vector, producing the identical left fold per `j`
+   (`0.0 + d1` is exact). Both vectors then enter the same central accumulate
+   (:3787). Same numbers, same order, same `daxpy`.
+3. *Topology.* §3's rewrite preserves the expression graph node-for-node, so
+   the worklist delivers contributions to `c0`/`c1` in the same sequence, and
+   the (non-associative) accumulate sums in the same order.
+
+Condition 2 is exactly why §2 rejects the in-place `.A` scatter for the first
+cut: writing `dA[i]` directly into a non-empty adjoint re-associates the sum
+(`((A+d1)+d2)` versus `A+(d1+d2)`) whenever the source's fan-out is above one
+— which it always is in a fit, where `c0` feeds every instrument on the shared
+tape. That variant is a real fingerprint risk and is deferred until the
+materialized version is validated end-to-end. **If the fingerprint moves
+anyway, stop and treat it as a bug in this analysis, not as noise** — the plan
+doc's rule.
+
+Verification order: in-repo tests (§4, all three runtimes) → `-- gather`
+parity mode → local-feed into Analytics → its 445 .NET + 222 JS tests →
+`-- fingerprint` → `-- stages 20`.
+
+## 8. Open questions, with recommendations
+
+1. **Names `Gather`/`Scatter`?** Yes — standard AD/array vocabulary, zero
+   collisions in the family (`rg Gather` finds nothing), and the pair names
+   its own adjoint relationship. Alternative `Select`/`SelectAdd` says less.
+2. **Materialized-scatter push versus in-place `.A` scatter?** Materialized
+   (§2, §7). Revisit in-place only after the fingerprint has a green history,
+   and then behind the constraint-5 guard (`DV`-and-`DV` only, matching
+   lengths), accepting that it re-associates sums and so likely moves the
+   fingerprint — it would need Analytics to re-baseline, a much bigger ask
+   than the saving (one length-m array per gather per pass) justifies today.
+3. **Validate bounds in release?** Yes, unconditionally (§1). The Fable
+   targets turn a bad index into silent NaN or a silently-dropped adjoint
+   write; there is no `#if DEBUG` convention in this file to hide behind.
+4. **A `DM` gather (rows/columns by index)?** Defer. No consumer need;
+   `SliceRow_DM`/`SliceCol_DM` cover the single-row cases, and the `GenMat`
+   off-diagonal `failwith "todo"` holes make DM work disproportionately
+   expensive to test.
+5. **`D`-returning single-index variant?** No — `d.[i]` / `Item_DV` is that
+   op already (:584, :3741).
+6. **Copy `ks` defensively?** No — matches the existing aliasing of `ks` into
+   `csrS.Columns`, and the callers build a fresh array per call anyway.
+   Document the no-mutation contract on the member.
+7. **Where do the kernels live?** `Backend.Lite.fs` (`Gather_V`,
+   `Scatter_V`), per the repo rule that numeric behaviour belongs in the
+   backend; `AD.Lite.fs` gets only the op plumbing.
+8. **Should `InterpolateV` validate `ks` sortedness now that gather doesn't
+   need it?** Out of scope here — an Analytics decision. Note only that the
+   gather rewrite removes the silent dependency from the differentiable path;
+   `LeftSegmentIndex(ts: float[])` still assumes sorted `ts`.

--- a/plans/ad-tape-allocation.md
+++ b/plans/ad-tape-allocation.md
@@ -1,8 +1,9 @@
 # Reverse-mode AD allocates ~2.5x what it needs to
 
 **Status: steps 1 and 2 landed 2026-08-07 (PR #18); step 4 followed the same
-day — see the step-4 section at the end. Step 3 is next, minding the
-empty-destination interaction described there.**
+day — see the step-4 section at the end. Step 3 is done as option (d) of
+`ad-allocation-redesign.md`, which now carries the direction; next is the
+gather op (`ad-gather.md`).**
 
 History: diagnosed 2026-08-05 with a harness (`consoles/BenchmarkAdTape`) and
 the cause confirmed at three specific lines. Step 1, the `adjoint`/`.A` consumer
@@ -252,12 +253,12 @@ is a plain `DV` (and, for push, `v` too), falling back to allocation otherwise.
    (`:3346`) returning a copy for exactly the same case split, in the same
    commit. Reset allocation went 115,656 → 2,136 B/pass and is now flat in
    vector width. Cross-runtime tests in `tests/ExpectoTests/AdjointLifetimeTests.fs`.
-3. **`:576`** — if reset reuses buffers, question whether construction needs to
-   allocate one eagerly at all. Mind the interaction with step 4: a non-empty
-   contribution accumulated into an empty sentinel adjoint is
-   `Backend.Add_V_V_Inplace`'s error path. Reset runs before every push
-   (`:3996`), so "buffers are full-length by push time" holds — keep that
-   invariant explicit.
+3. ~~**`:576`**~~ — **done 2026-08-07** as option (d) of
+   `ad-allocation-redesign.md`: `DV.R`/`DM.R` seed the adjoint ref with a shared
+   empty sentinel and reset's shape-mismatch arm materialises on first visit.
+   The "buffers are full-length by push time" invariant is pinned by a test, and
+   the harness's phases/seeds modes now report the first pass separately.
+   Measured outcome in the redesign note.
 4. ~~**`:3746`** — in-place adjoint accumulation.~~ — **done 2026-08-07.** The
    `DV` and `DM` central accumulates now go through the previously dormant
    `Add_V_V_Inplace`/`Add_M_M_Inplace`; push went 227,432 → 115,472 B/pass

--- a/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
+++ b/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
@@ -573,7 +573,10 @@ and DV =
     member d.GetReverse(i:uint32) = DV.R(d, Noop, i)
 
     /// Make a reverse node
-    static member R(d, op, ai) = DVR(d, ref (DV.ZeroN d.Length), op, ref 0u, ai)
+    // The adjoint starts as the shared empty sentinel rather than an eager
+    // full-length zero vector: `reverseReset` runs before every push and its
+    // shape-mismatch arm materialises the buffer on the node's first reset.
+    static member R(d, op, ai) = DVR(d, ref DV.ZeroSentinel, op, ref 0u, ai)
 
     member d.Length =
         match d with
@@ -644,6 +647,10 @@ and DV =
         sb.ToString()
 
     static member Zero = DV Array.empty
+    // One shared instance can seed every reverse node's adjoint: it is never
+    // mutated, because reset's in-place clear fires only on a length match —
+    // which for the sentinel means an empty primal and a no-op clear.
+    static member val internal ZeroSentinel = DV Array.empty
 
     static member ZeroN n = DV(Array.zeroCreate n)
 
@@ -1566,7 +1573,9 @@ and DM =
     member d.GetReverse(i:uint32) = DM.R(d, Noop, i)
 
     /// Make a reverse node
-    static member R(cp, op, ai) = DMR(cp, ref (DM.ZeroMN cp.Rows cp.Cols), op, ref 0u, ai)
+    // As for `DV.R`: the empty sentinel, materialised by reset's shape-mismatch
+    // arm on the node's first reset.
+    static member R(cp, op, ai) = DMR(cp, ref DM.ZeroSentinel, op, ref 0u, ai)
 
     member d.Length =
         match d with
@@ -1665,6 +1674,8 @@ and DM =
         sb.ToString()
 
     static member Zero = GenMat.empty |> DM
+    // See `DV.ZeroSentinel`; `GenMat.empty` is itself a shared module value.
+    static member val internal ZeroSentinel = GenMat.empty |> DM
 
     static member ZeroMN m n = DM (Mat.zeroCreate m n |> ColMajor)
 

--- a/tests/ExpectoTests/AdjointLifetimeTests.fs
+++ b/tests/ExpectoTests/AdjointLifetimeTests.fs
@@ -78,6 +78,36 @@ let tests =
       row1.[0] |> Expect.floatClose "seed 1 [0]" accuracy 1.0
       row1.[1] |> Expect.floatClose "seed 1 [1]" accuracy 1.0
 
+    testCase "a node's adjoint is lazy — empty until a reverse pass materialises it" <| fun _ ->
+      // `DV.R`/`DM.R` seed the adjoint ref with the shared empty sentinel; the
+      // full-length buffer only exists once `reverseReset`'s shape-mismatch arm
+      // has run. The passing push below is the invariant that keeps
+      // `Add_V_V_Inplace`'s empty-destination error path unreachable: reset runs
+      // before every push, so buffers are full-length by push time.
+      let xa = DV [| 3.0; 5.0 |] |> makeReverse (nextTag ())
+      let z = xa.[0] * xa.[1]
+      (xa |> adjoint |> DV.toFloats).Length |> Expect.equal "adjoint before any pass is the empty sentinel" 0
+      z |> reverseProp D.One
+      let g = xa |> adjoint |> DV.toFloats
+      g.Length |> Expect.equal "materialised to primal length by the pass" 2
+      g.[0] |> Expect.floatClose "d(x*y)/dx" accuracy 5.0
+      g.[1] |> Expect.floatClose "d(x*y)/dy" accuracy 3.0
+
+    testCase "nested forward-over-reverse works over lazy adjoints" <| fun _ ->
+      // Forward-on-reverse — the shape that puts DVF duals into adjoint refs
+      // (constraint 5) — built as Hessian-vector products via the forward
+      // directional derivative of the reverse-mode gradient. Deliberately not
+      // `gradhessian`, whose DM assembly is `failwith` under Fable; this form
+      // runs on all three targets.
+      let f (v: DV) = v.[0] * v.[1] * v.[1]
+      let x = DV [| 3.0; 5.0 |]
+      let hcol0 = jacobianv (grad f) x (DV [| 1.0; 0.0 |]) |> DV.toFloats
+      let hcol1 = jacobianv (grad f) x (DV [| 0.0; 1.0 |]) |> DV.toFloats
+      hcol0.[0] |> Expect.floatClose "H[0,0] = 0" accuracy 0.0
+      hcol0.[1] |> Expect.floatClose "H[1,0] = 2y" accuracy 10.0
+      hcol1.[0] |> Expect.floatClose "H[0,1] = 2y" accuracy 10.0
+      hcol1.[1] |> Expect.floatClose "H[1,1] = 2x" accuracy 6.0
+
     testCase "an extra reverseReset disarms the push that follows (known trap)" <| fun _ ->
       // resetRec bumps each node's fan-out counter and recurses only when it hits
       // exactly 1, so a second reset with no push in between walks the root alone and


### PR DESCRIPTION
Step 3 of `plans/ad-tape-allocation.md`, i.e. option (d) of the new
`plans/ad-allocation-redesign.md` direction note: stop allocating a full-length
zero adjoint at every reverse-node construction.

## The change

`DV.R` / `DM.R` now seed their adjoint ref with a **shared empty sentinel** per
type; `reverseReset`'s existing shape-mismatch arm materialises the full-length
buffer on the node's first visit, so there is no new code at the push site.
Sharing one instance is safe because the sentinel is never mutated: reset's
in-place clear fires only on a length match, which for the sentinel means an
empty primal and a no-op clear.

The invariant that keeps `Add_V_V_Inplace`'s empty-destination error path
unreachable — *reset runs before every push, so buffers are full-length by push
time* — was documented in #19's plan section and is now pinned by a test.

## Results

Depth 8, `-- phases`:

| phase | before | after |
| --- | ---: | ---: |
| forward, builds tape | 229,040 | **118,464** |
| reset, steady state | 2,136 | 2,136 |
| reverseProp, steady state | 117,608 | 117,608 |
| first pass on a fresh tape | — | 228,184 |

BDN `Forward` drops 223.67 → **115.69 KB**; `ForwardAndReset`,
`ForwardResetAndPush` and `ForwardThenSeedPasses` totals are unchanged — the
materialisation moved into the first reverse pass, so a fully-visited tape nets
**zero**. The saving accrues to tapes and cones that are never
reverse-visited.

**Downstream that population is currently empty.** An A/B on the same
`WldMr.Analytics` commit (stock master vs this branch through the local feed)
gives **54.7 MB per MarketBuild fit both ways**: the recent bond work
("z-spread on floats when nothing is differentiating") already removed the
forward-only tapes by hand. This change is the same fix made structural — any
future consumer path that evaluates reverse-typed values without
differentiating stops paying for adjoints it never uses.

## Harness honesty fix

`-- phases` measured `reverseProp` on a fresh tape, which now conflates
materialisation with push and broke the derived push number. `measureOnce`
gained a second push (legal: a complete push returns every fan-out counter to
zero), so steady state and first pass are separate rows; the `seeds` mode
splits pass 1 out the same way. The BDN class docs are updated — the
subtraction rows measure the first pass, `ReversePassOnPrebuiltTape` is the
steady state.

## Tests

Two new cross-runtime tests in `AdjointLifetimeTests.fs`:

- the lazy contract: adjoint is empty before any pass, full-length with correct
  values after — the passing push is the invariant proof;
- the nested forward-on-reverse case (constraint 5), built as Hessian-vector
  products via `jacobianv (grad f)` because `gradhessian`'s `DM` assembly is a
  `failwith` under Fable.

## Verification

- `dotnet test`: 16 + 13 + 35 passed, 6 skipped (the pre-existing `[<Ignore>]`).
- `npm test` (Fable→JS) and Fable→Python: 13 passing each.
- Downstream via the local folder feed: all 445 .NET and 222 Fable/JS tests
  pass; `BenchmarkMarketBuild -- fingerprint` **byte-identical**
  (`15a6fee3…`).

## Also in this PR

`plans/ad-allocation-redesign.md` (the direction note) and `plans/ad-gather.md`
(the gather-op design, next up) enter the repo; option (d) and step 3 are
marked done in both plans with the measured outcome, including the correction
that the `DV.ZeroN` trace line shifts to `resetRec` rather than disappearing.
