### PR TITLE
AD: a first-class reverse-mode gather/scatter for DV

### DIFF
--- a/consoles/BenchmarkAdTape/Benchmarks.fs
+++ b/consoles/BenchmarkAdTape/Benchmarks.fs
@@ -112,3 +112,46 @@ type AdTapeBenchmark() =
     for _ in 1 .. Graph.SeedPasses do
       reverseProp (D.One :> dobj) (root :> dobj)
     x |> adjoint: DV
+
+
+/// The `InterpolateV` shape (`Graph.GatherShape`), selection-CSR versus gather,
+/// forward-only and with one reverse pass. `c0`/`c1` are `makeReverse`'d per
+/// invocation, as `CurveSolver` would hold them. Read `Allocated`, as above;
+/// `-- gather` is the fast runner for the same shape and also asserts bit
+/// parity between the two formulations.
+[<MemoryDiagnoser>]
+type GatherBenchmark() =
+
+  let seed = DV (Array.create Graph.GatherShape.n 1.0)
+
+  [<Benchmark(Baseline = true)>]
+  member _.CsrForward() =
+    let i = WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+    let c0 = DV Graph.GatherShape.c0f |> makeReverse i
+    let c1 = DV Graph.GatherShape.c1f |> makeReverse i
+    Graph.GatherShape.interpolateCsr c0 c1
+
+  [<Benchmark>]
+  member _.GatherForward() =
+    let i = WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+    let c0 = DV Graph.GatherShape.c0f |> makeReverse i
+    let c1 = DV Graph.GatherShape.c1f |> makeReverse i
+    Graph.GatherShape.interpolateGather c0 c1
+
+  [<Benchmark>]
+  member _.CsrForwardAndReverse() =
+    let i = WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+    let c0 = DV Graph.GatherShape.c0f |> makeReverse i
+    let c1 = DV Graph.GatherShape.c1f |> makeReverse i
+    let y = Graph.GatherShape.interpolateCsr c0 c1
+    reverseProp (seed :> dobj) (y :> dobj)
+    struct ((c0 |> adjoint: DV), (c1 |> adjoint: DV))
+
+  [<Benchmark>]
+  member _.GatherForwardAndReverse() =
+    let i = WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+    let c0 = DV Graph.GatherShape.c0f |> makeReverse i
+    let c1 = DV Graph.GatherShape.c1f |> makeReverse i
+    let y = Graph.GatherShape.interpolateGather c0 c1
+    reverseProp (seed :> dobj) (y :> dobj)
+    struct ((c0 |> adjoint: DV), (c1 |> adjoint: DV))

--- a/consoles/BenchmarkAdTape/Graph.fs
+++ b/consoles/BenchmarkAdTape/Graph.fs
@@ -158,3 +158,52 @@ let nodeCount (spec: GraphSpec) = 1 + spec.Depth * 7 + 1
 /// kills the hypothesis — `Phases.phases` prints the ratio.
 let adjointSlots (spec: GraphSpec) =
   spec.Pillars + spec.Depth * (5 * spec.Points + 2 * spec.Pillars)
+
+
+/// The `InterpolateV` shape from `WldMr.Analytics` (plans/ad-gather.md §3): the
+/// selection-CSR formulation exactly as `Curve/LinearInterpolation.fs` builds
+/// it per call, and the gather rewrite that replaces it. Standard harness
+/// width: 40 pillars, 320 points.
+module GatherShape =
+
+  let m = 40
+  let n = 320
+
+  /// sorted knots, and sorted query points spanning them
+  let x : float[] = Array.init m (fun i -> 0.25 * float i)
+  let ts : float[] = Array.init n (fun i -> 0.25 * float (m - 1) * (float i + 0.5) / float n)
+  /// left-knot index per query — non-decreasing because `ts` is sorted, which
+  /// the hand-built CSR transpose requires (gather itself does not)
+  let ks : int[] = ts |> Array.map (fun t -> min (m - 2) (int (t / 0.25)))
+  let c0f : float[] = Array.init m (fun i -> 1.0 + 0.01 * float i)
+  let c1f : float[] = Array.init m (fun i -> 0.5 + 0.001 * float i)
+
+  /// exactly `InterpolateV`: selection CSR plus its hand-built transpose,
+  /// constructed on every call — the transpose exists only so the reverse pass
+  /// of `Mul_DMCons_DV` gets `DM.Transpose(cons)` for free
+  let interpolateCsr (c0: DV) (c1: DV) : DV =
+    let csrS =
+      { Values = Array.create n 1.; Columns = ks
+        RowIndices = Array.init (n + 1) id; NCols = m }
+    let csrST =
+      let colIndices = Array.zeroCreate (m + 1)
+      let mutable ksIdx = 0
+      for i in 0 .. m - 1 do
+        while ksIdx < n && i >= ks.[ksIdx] do ksIdx <- ksIdx + 1
+        colIndices.[i + 1] <- ksIdx
+      { Values = Array.create n 1.; Columns = Array.init n id
+        RowIndices = colIndices; NCols = n }
+    let dmS = DM (SparseDouble (csrS, csrST))
+    let vX = CsrMat.mulV csrS x
+    let dTsX = Blas.sub_V_V (ts, vX)
+    let a = dmS * c0
+    let b = (dmS * c1) .* DV dTsX
+    DV.Add_V_V_Inplace(a, b)
+
+  /// the plans/ad-gather.md §3 rewrite
+  let interpolateGather (c0: DV) (c1: DV) : DV =
+    let vX = Array.init n (fun i -> x.[ks.[i]])
+    let dTsX = Blas.sub_V_V (ts, vX)
+    let a = DV.Gather(c0, ks)
+    let b = DV.Gather(c1, ks) .* DV dTsX
+    DV.Add_V_V_Inplace(a, b)

--- a/consoles/BenchmarkAdTape/Phases.fs
+++ b/consoles/BenchmarkAdTape/Phases.fs
@@ -235,3 +235,52 @@ let seedPasses (spec: Graph.GraphSpec) (reps: int) =
     (Graph.SeedPasses - 1) rest (rest / float (Graph.SeedPasses - 1))
   printfn "  total                     %12.0f B  (%.1f%% of it reverse)"
     (fwd + first + rest) (100.0 * (first + rest) / (fwd + first + rest))
+
+
+/// Both formulations of the `InterpolateV` shape (`Graph.GatherShape`):
+/// forward-build and reverse-pass allocation for each, behind a standing
+/// bit-parity assertion — value and both gradients must differ by exactly
+/// 0.0, which is plans/ad-gather.md §7's claim in runnable form.
+let gather (reps: int) =
+  let seed = DV (Array.create Graph.GatherShape.n 1.0)
+  let runOnce (interp: DV -> DV -> DV) =
+    let i = WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+    let c0 = DV Graph.GatherShape.c0f |> makeReverse i
+    let c1 = DV Graph.GatherShape.c1f |> makeReverse i
+    let a0 = alloc ()
+    let y = interp c0 c1
+    let a1 = alloc ()
+    reverseProp (seed :> dobj) (y :> dobj)
+    let a2 = alloc ()
+    let p = y.P |> DV.toFloats
+    let g0 = (c0 |> adjoint: DV) |> DV.toFloats
+    let g1 = (c1 |> adjoint: DV) |> DV.toFloats
+    p, g0, g1, a1 - a0, a2 - a1
+
+  // Parity before numbers, so a broken formulation cannot publish a fast row.
+  let pC, g0C, g1C, _, _ = runOnce Graph.GatherShape.interpolateCsr
+  let pG, g0G, g1G, _, _ = runOnce Graph.GatherShape.interpolateGather
+  let maxAbsDiff (a: float[]) (b: float[]) =
+    Array.map2 (fun (x: float) y -> abs (x - y)) a b |> Array.max
+  let dv, d0, d1 = maxAbsDiff pC pG, maxAbsDiff g0C g0G, maxAbsDiff g1C g1G
+  if dv <> 0.0 || d0 <> 0.0 || d1 <> 0.0 then
+    failwithf "bit parity broken: value %g, grad c0 %g, grad c1 %g — see plans/ad-gather.md" dv d0 d1
+
+  let measure interp =
+    runOnce interp |> ignore // warm
+    let mutable fwd = 0L
+    let mutable rev = 0L
+    for _ in 1 .. reps do
+      let _, _, _, f, r = runOnce interp
+      fwd <- fwd + f
+      rev <- rev + r
+    float fwd / float reps, float rev / float reps
+
+  let fC, rC = measure Graph.GatherShape.interpolateCsr
+  let fG, rG = measure Graph.GatherShape.interpolateGather
+  printfn "gather  pillars=%d points=%d, %d reps — values and gradients bit-identical"
+    Graph.GatherShape.m Graph.GatherShape.n reps
+  printfn "  formulation      forward B/call   reverse B/pass"
+  printfn "  selection CSR  %16.0f %16.0f" fC rC
+  printfn "  gather         %16.0f %16.0f" fG rG
+  printfn "  saving         %16.0f %16.0f" (fC - fG) (rC - rG)

--- a/consoles/BenchmarkAdTape/Program.fs
+++ b/consoles/BenchmarkAdTape/Program.fs
@@ -23,6 +23,8 @@ let private usage () =
   printfn "                                              # one forward, N reverse passes"
   printfn "  dotnet run -c Release -- profile [n=200] [depth=8]"
   printfn "                                              # bare loop, for an external profiler"
+  printfn "  dotnet run -c Release -- gather [reps=20]   # InterpolateV shape: CSR vs gather,"
+  printfn "                                              # bit-parity asserted"
 
 /// Parse a positive int, or report which argument was wrong.
 let private posInt (name: string) (s: string) =
@@ -41,6 +43,7 @@ let main argv =
     Phases.census (Graph.spec 8)
     printfn ""
     BenchmarkRunner.Run<Benchmarks.AdTapeBenchmark>() |> ignore
+    BenchmarkRunner.Run<Benchmarks.GatherBenchmark>() |> ignore
     0
   | [ "census" ] -> Phases.census (Graph.spec 8); 0
   | [ "census"; d ] ->
@@ -75,6 +78,11 @@ let main argv =
     match posInt "depth" d, posInt "reps" r with
     | Some d, Some r -> Phases.seedPasses (Graph.spec d) r; 0
     | _ -> 1
+  | [ "gather" ] -> Phases.gather 20; 0
+  | [ "gather"; r ] ->
+    match posInt "reps" r with
+    | Some r -> Phases.gather r; 0
+    | None -> 1
   | [ "profile" ] -> Phases.profile (Graph.spec 8) 200; 0
   | [ "profile"; n ] ->
     match posInt "n" n with

--- a/plans/ad-gather.md
+++ b/plans/ad-gather.md
@@ -1,7 +1,26 @@
 # A first-class reverse-mode `gather` for `DV`
 
-**Status: design, 2026-08-07. Nothing implemented. Written against master at
-`1af3889` ("accumulate adjoints in place on reverse push").**
+**Status: implemented 2026-08-07 on the `ad-lazy-adjoint-init` branch. §1–§2
+and §4–§6 landed as designed; §3, the `InterpolateV` rewrite, was verified as a
+working-tree preview against the local feed and reverted — it ships as the
+Analytics adoption PR once a release carries the op.**
+
+Measured with the preview live: all 445 + 222 downstream tests green, the
+MarketBuild fingerprint **byte-identical** cross-process (§7 held end-to-end),
+whole fit **54.7 → 50.0 MB** (−8.6%), the saving inside
+`fitOisCurves`/`fitLocalSpreadCurves`/`bondCurves`. In-repo (BDN): gather is
+**2.4x faster and 33% lighter** than the CSR formulation forward (1.79 vs
+4.24 µs, 16.1 vs 24.0 KB), reverse a wash by design; `-- gather` asserts bit
+parity on every run.
+
+Two corrections earned in practice: `MochaFlip.isTrue` existed only for JS and
+needed adding to the Python branch (the CLAUDE.md both-branches rule); and §1's
+"one integer compare per element … noise" was false as first written —
+per-element `.Length` property calls made validation cost more than the matvec
+it replaced. Validation now hoists the bound and runs only in the public entry,
+with a private `*NoCheck` core for the op's own primal/tangent recursion.
+
+The design note follows, written against master at `1af3889`.
 
 Line references are against that commit. `AD.Lite.fs` means
 `src/WldMr.Numerics.DiffSharp/AD.Lite.fs` (4,224 lines) unless said otherwise.

--- a/plans/ad-tape-allocation.md
+++ b/plans/ad-tape-allocation.md
@@ -2,8 +2,9 @@
 
 **Status: steps 1 and 2 landed 2026-08-07 (PR #18); step 4 followed the same
 day — see the step-4 section at the end. Step 3 is done as option (d) of
-`ad-allocation-redesign.md`, which now carries the direction; next is the
-gather op (`ad-gather.md`).**
+`ad-allocation-redesign.md`, which now carries the direction; the gather op
+(`ad-gather.md`) is implemented and verified, awaiting the Analytics adoption
+PR after release.**
 
 History: diagnosed 2026-08-05 with a harness (`consoles/BenchmarkAdTape`) and
 the cause confirmed at three specific lines. Step 1, the `adjoint`/`.A` consumer

--- a/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
+++ b/src/WldMr.Numerics.DiffSharp/AD.Lite.fs
@@ -1183,6 +1183,49 @@ and DV =
         let inline r_c_d(a, b) = AddSubVector_DVCons_DV(i, b)
         DV.Op_DV_DV_DV (a, b, ff, fd, df_da, df_db, df_dab, r_d_d, r_d_c, r_c_d)
 
+    // The op body without validation, for the primal/tangent recursion below —
+    // `Gather` has already validated `ks` against this exact length by the time
+    // any of these fire.
+    static member private GatherNoCheck (a: DV, ks: int[]) =
+        let inline ff(a) = Backend.Gather_V(a, ks)
+        let inline fd(a: DV) = DV.GatherNoCheck(a, ks)
+        let inline df(cp: DV, ap: DV, at: DV) = DV.GatherNoCheck(at, ks)
+        let inline r(a) = Gather_DV(a, ks)
+        DV.Op_DV_DV (a, ff, fd, df, r)
+
+    /// `result.[i] = a.[ks.[i]]`. Linear; its reverse rule is `Scatter`. The
+    /// index array is captured without copying — the caller must not mutate it
+    /// after the call, and the tape keeps it alive until the tape dies.
+    static member Gather (a: DV, ks: int[]) =
+        // Validated always: Fable→JS reads `undefined` (NaN) and drops writes
+        // out of bounds, Fable→Python wraps negatives — only .NET throws on its
+        // own. The bound is hoisted: per-element `.Length` calls dominate the op.
+        let alen = a.Length
+        for i in 0 .. ks.Length - 1 do
+            let k = ks.[i]
+            if k < 0 || k >= alen then ErrorMessages.InvalidArgGatherIndex()
+        if ks.Length = 0 then DV.Zero
+        else DV.GatherNoCheck(a, ks)
+
+    static member private ScatterNoCheck (b: DV, ks: int[], n: int) =
+        let inline ff(b) = Backend.Scatter_V(b, ks, n)
+        let inline fd(b: DV) = DV.ScatterNoCheck(b, ks, n)
+        let inline df(cp: DV, bp: DV, bt: DV) = DV.ScatterNoCheck(bt, ks, n)
+        let inline r(b) = Scatter_DV(b, ks)
+        DV.Op_DV_DV (b, ff, fd, df, r)
+
+    /// The adjoint pair of `Gather`: a length-`n` vector where slot `ks.[i]`
+    /// accumulates `b.[i]` — duplicate indices add, in ascending `i` order.
+    /// First-class (rather than private to the reverse pass) because nested AD
+    /// needs it to be a proper op: a `DVF` adjoint dispatches through it.
+    static member Scatter (b: DV, ks: int[], n: int) =
+        if ks.Length <> b.Length then ErrorMessages.InvalidArgScatterLength()
+        for i in 0 .. ks.Length - 1 do
+            let k = ks.[i]
+            if k < 0 || k >= n then ErrorMessages.InvalidArgGatherIndex()
+        if ks.Length = 0 then DV.ZeroN n
+        else DV.ScatterNoCheck(b, ks, n)
+
     // DV - number binary operations
     static member (+) (a:DV, b:number) = a + D b
     static member (-) (a:DV, b:number) = a - D b
@@ -2819,6 +2862,8 @@ and TraceOp =
     | AddSubVector_DVCons_DV of int * DV
     | ReshapeCopy_DM_DV      of DM
     | Slice_DV               of DV * int
+    | Gather_DV              of DV * int[]
+    | Scatter_DV             of DV * int[]
     | Diagonal_DM            of DM
     | ReLU_DV                of DV
     | Sigmoid_DV             of DV
@@ -2950,6 +2995,9 @@ module DV =
 
     /// Converts vector `v` into a column matrix
     let inline toColDM (v:DV) = v.ToColDM()
+
+    /// `result.[i] = v.[ks.[i]]` — see `DV.Gather`
+    let inline gather (ks: int[]) (v: DV) = DV.Gather(v, ks)
 
 
 //    /// Creates a vector with `n` elements, each with value `v`
@@ -3556,6 +3604,8 @@ module DOps =
                             | AddSubVector_DVCons_DV(_, b) -> resetRec (bxd b :: t)
                             | ReshapeCopy_DM_DV(a) -> resetRec (bxd a :: t)
                             | Slice_DV(a, _) -> resetRec (bxd a :: t)
+                            | Gather_DV(a, _) -> resetRec (bxd a :: t)
+                            | Scatter_DV(b, _) -> resetRec (bxd b :: t)
                             | Diagonal_DM(a) -> resetRec (bxd a :: t)
                             | ReLU_DV(a) -> resetRec (bxd a :: t)
                             | Sigmoid_DV(a) -> resetRec (bxd a :: t)
@@ -3904,6 +3954,11 @@ module DOps =
                             | Slice_DV(a, i) ->
                                 a.A <- DV.AddSubVector(a.A, i, dA)
                                 pushRec ((bxv DV.Zero a) :: t)
+                            // Through the central accumulate, not the `.A <-` bypass style
+                            // above: the materialized vector is a fresh, uniquely-owned
+                            // contribution, and a `DVF` adjoint dispatches through the ops.
+                            | Gather_DV(a, ks) -> pushRec ((bxv (DV.Scatter(dA, ks, a.Length)) a) :: t)
+                            | Scatter_DV(b, ks) -> pushRec ((bxv (DV.Gather(dA, ks)) b) :: t)
                             | Diagonal_DM(a) ->
                                 a.A <- DM.AddDiagonal(a.A, dA)
                                 pushRec ((bxm DM.Zero a) :: t)

--- a/src/WldMr.Numerics.DiffSharp/Backend.Lite.fs
+++ b/src/WldMr.Numerics.DiffSharp/Backend.Lite.fs
@@ -78,6 +78,22 @@ module Lite =
             Blas.daxpy(xl, -1., y, 1, x', 1)
             x'
 
+    static member inline Gather_V(x: float[], ks: int[]) =
+        let r = Array.zeroCreate ks.Length
+        for i in 0 .. ks.Length - 1 do
+            r.[i] <- x.[ks.[i]]
+        r
+
+    static member inline Scatter_V(x: float[], ks: int[], n: int) =
+        let r = Array.zeroCreate n
+        for i in 0 .. ks.Length - 1 do
+            let k = ks.[i]
+            // Duplicates add, in ascending `i` — the same left fold per slot as
+            // a CSR-transpose mat-vec built from `ks`, which is what makes the
+            // gather formulation bit-identical to the selection-matrix one.
+            r.[k] <- r.[k] + x.[i]
+        r
+
     // BLAS
     static member inline Mul_Dot_V_V(x: float[], y: float[]) =
         let xl = x.Length

--- a/src/WldMr.Numerics.DiffSharp/Util.fs
+++ b/src/WldMr.Numerics.DiffSharp/Util.fs
@@ -108,6 +108,8 @@ module ErrorMessages =
     let InvalidArgMM() = invalidArg "" "Matrices must have same shape."
     let InvalidArgVMRows() = invalidArg "" "Length of vector must match number of rows of matrix."
     let InvalidArgVMCols() = invalidArg "" "Length of vector must match number of columns of matrix."
+    let InvalidArgGatherIndex() = invalidArg "" "Gather/scatter index out of range."
+    let InvalidArgScatterLength() = invalidArg "" "Scatter value vector and index array must have same length."
 
 
 /// Tagger for generating incremental integers

--- a/tests/ExpectoTests/ExpectoTests.fsproj
+++ b/tests/ExpectoTests/ExpectoTests.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="BasicTests.fs" />
     <Compile Include="CscMatTests.fs" />
     <Compile Include="AdjointLifetimeTests.fs" />
+    <Compile Include="GatherTests.fs" />
     <Compile Include="Main.fs" />
     <None Include="paket.references" />
   </ItemGroup>

--- a/tests/ExpectoTests/GatherTests.fs
+++ b/tests/ExpectoTests/GatherTests.fs
@@ -1,0 +1,97 @@
+module GatherTests
+
+#if FABLE_COMPILER_PYTHON
+open Fable.Pyxpecto
+#endif
+#if FABLE_COMPILER_JAVASCRIPT
+open Fable.Mocha
+#endif
+#if !FABLE_COMPILER
+open Expecto
+open Expecto.Flip
+#else
+type TestsAttribute() =
+  inherit System.Attribute()
+#endif
+
+open WldMr.Numerics.DiffSharp.AD.Float64
+
+open MochaFlip
+
+let accuracy = { absolute = 1e-9; relative = 0. }
+
+let private raises (f: unit -> 'a) =
+  try
+    f () |> ignore
+    false
+  with _ -> true
+
+/// `Gather`/`Scatter` per plans/ad-gather.md. The reverse-pass cases sit behind
+/// `pushRec`/`resetRec` wildcards, so a forgotten case compiles clean — tests 2
+/// and 3 are the tripwires for exactly those two omissions.
+[<Tests>]
+let tests =
+  testList "gather" [
+
+    testCase "forward picks by index, duplicates and unsorted allowed" <| fun _ ->
+      let v = DV [| 3.0; 5.0; 7.0 |]
+      let g = DV.Gather(v, [| 2; 0; 0; 1 |]) |> DV.toFloats
+      g.Length |> Expect.equal "length follows ks" 4
+      g.[0] |> Expect.floatClose "picked [2]" accuracy 7.0
+      g.[1] |> Expect.floatClose "picked [0]" accuracy 3.0
+      g.[2] |> Expect.floatClose "picked [0] again" accuracy 3.0
+      g.[3] |> Expect.floatClose "picked [1]" accuracy 5.0
+      (v |> DV.gather [| 1 |] |> DV.toFloats).[0]
+        |> Expect.floatClose "module helper" accuracy 5.0
+      (DV.Gather(v, [||]) |> DV.toFloats).Length
+        |> Expect.equal "empty ks is DV.Zero, no node" 0
+      // Scatter forward: duplicates ADD into the slot
+      let s = DV.Scatter(DV [| 1.0; 2.0; 3.0 |], [| 1; 1; 0 |], 4) |> DV.toFloats
+      s.[0] |> Expect.floatClose "slot 0" accuracy 3.0
+      s.[1] |> Expect.floatClose "slot 1 accumulates 1+2" accuracy 3.0
+      s.[2] |> Expect.floatClose "untouched slot" accuracy 0.0
+      s.[3] |> Expect.floatClose "untouched slot" accuracy 0.0
+
+    testCase "reverse with duplicate indices: the scatter must ADD" <| fun _ ->
+      // d/dv of sum(gather(v, [1;1;0])) = scatter of ones = [|1; 2|]. Goes red
+      // if the pushRec case is forgotten (silent zero through the wildcard) or
+      // if a future in-place scatter overwrites instead of accumulating.
+      let g = grad (fun (v: DV) -> DV.Sum(DV.Gather(v, [| 1; 1; 0 |]))) (DV [| 3.0; 5.0 |])
+              |> DV.toFloats
+      g.[0] |> Expect.floatClose "index 0 picked once" accuracy 1.0
+      g.[1] |> Expect.floatClose "index 1 picked twice" accuracy 2.0
+
+    testCase "fan-out: one source feeding two gather nodes" <| fun _ ->
+      // Red if the resetRec case is forgotten: the source never arms, and with
+      // lazy adjoints the push then meets an unmaterialised buffer.
+      let g = grad (fun (v: DV) -> DV.Sum(DV.Gather(v, [| 0; 1 |]) + DV.Gather(v, [| 1; 0 |])))
+                   (DV [| 3.0; 5.0 |])
+              |> DV.toFloats
+      g.[0] |> Expect.floatClose "both scatters contribute" accuracy 2.0
+      g.[1] |> Expect.floatClose "both scatters contribute" accuracy 2.0
+
+    testCase "nested forward-over-reverse through a gather" <| fun _ ->
+      // Constraint-5 shape: a DVF adjoint dispatches through Scatter's own
+      // Op_DV_DV case. f v = sum(gather(v,[1;1;0]) .* gather(v,[1;1;0]))
+      // = v0^2 + 2 v1^2, so H = diag(2, 4).
+      let f (v: DV) =
+        let s = DV.Gather(v, [| 1; 1; 0 |])
+        DV.Sum(s .* s)
+      let x = DV [| 3.0; 5.0 |]
+      let hcol0 = jacobianv (grad f) x (DV [| 1.0; 0.0 |]) |> DV.toFloats
+      let hcol1 = jacobianv (grad f) x (DV [| 0.0; 1.0 |]) |> DV.toFloats
+      hcol0.[0] |> Expect.floatClose "H[0,0]" accuracy 2.0
+      hcol0.[1] |> Expect.floatClose "H[1,0]" accuracy 0.0
+      hcol1.[0] |> Expect.floatClose "H[0,1]" accuracy 0.0
+      hcol1.[1] |> Expect.floatClose "H[1,1]" accuracy 4.0
+
+    testCase "bounds are validated on every target" <| fun _ ->
+      // Under Fable→JS an out-of-bounds typed-array read is `undefined` and a
+      // write is silently dropped; under Fable→Python a negative index wraps.
+      // This test running under Fable is the point — .NET throws on its own.
+      let v = DV [| 3.0; 5.0; 7.0 |]
+      raises (fun () -> DV.Gather(v, [| 3 |])) |> Expect.isTrue "index = length"
+      raises (fun () -> DV.Gather(v, [| -1 |])) |> Expect.isTrue "negative index"
+      raises (fun () -> DV.Scatter(DV [| 1.0 |], [| 2 |], 2)) |> Expect.isTrue "scatter index = n"
+      raises (fun () -> DV.Scatter(DV [| 1.0; 2.0 |], [| 0 |], 3)) |> Expect.isTrue "length mismatch"
+  ]

--- a/tests/ExpectoTests/Main.fs
+++ b/tests/ExpectoTests/Main.fs
@@ -18,6 +18,7 @@ let all =
       BasicTests.tests
       CscMatTests.tests
       AdjointLifetimeTests.tests
+      GatherTests.tests
     ]
 
 [<EntryPoint>]

--- a/tests/ExpectoTests/MochaFlip.fs
+++ b/tests/ExpectoTests/MochaFlip.fs
@@ -45,6 +45,9 @@ module Expect =
 #if FABLE_COMPILER_PYTHON
   let inline equal message x y =
     Fable.Pyxpecto.Expect.equal x y message
+
+  let isTrue message x =
+    Fable.Pyxpecto.Expect.isTrue x message
 #endif
 #if FABLE_COMPILER_JAVASCRIPT
   let isTrue message x =

--- a/tests/WldMr.Numerics.DiffSharp.Checks/AD.Float64.fs
+++ b/tests/WldMr.Numerics.DiffSharp.Checks/AD.Float64.fs
@@ -10,6 +10,8 @@ module WldMr.Numerics.DiffSharp.Tests.AD.Float64
 open FsCheck.NUnit
 open WldMr.Numerics.DiffSharp.Tests
 open WldMr.Numerics.DiffSharp.AD.Float64
+open WldMr.Numerics.LinAlg
+open WldMr.Numerics.LinAlg.CsrMat
 
 [<Property>]
 let ``FixedPoint forward``() =
@@ -67,3 +69,61 @@ let ``Gradient descent (with arrays)``() =
         cos x'.[0,0]
 
     minimize lossFunction (DV.createOfFloat (n*n) 1.0) //Smoke test
+
+
+[<Property>]
+let ``Gather reverse gradient matches finite differences``(v0: float[], w0: float[], ks0: int[]) =
+    let v = v0 |> Array.map (fun x -> if Util.IsNice(x) then x % 10. else 1.0)
+    if v.Length = 0 || ks0.Length = 0 then true
+    else
+        // abs after %, so Int32.MinValue cannot overflow
+        let ks = ks0 |> Array.map (fun k -> abs (k % v.Length))
+        let w = Array.init ks.Length (fun i -> if i < w0.Length && Util.IsNice(w0.[i]) then w0.[i] % 10. else 1.0)
+        // Linear in v, so a weighted-sum probe covers the whole Jacobian and the
+        // forward-difference reference is exact up to rounding.
+        let gAD = grad (fun (u: DV) -> DV.Sum(DV.Gather(u, ks) .* DV w)) (DV v) |> DV.toFloats
+        let fN (u: float[]) = Seq.init ks.Length (fun i -> u.[ks.[i]] * w.[i]) |> Seq.sum
+        let gN = WldMr.Numerics.DiffSharp.Numerical.Float64.DiffOps.grad fN v
+        Util.(=~)(gAD, gN)
+
+[<Property>]
+let ``Gather equals the CSR selection-matrix formulation exactly``(c0: float[], ks0: int[]) =
+    // The in-repo canary for the InterpolateV rewrite (plans/ad-gather.md §7):
+    // the gather formulation must produce bit-identical primals and reverse
+    // gradients to the selection-CSR one it replaces. `=`, not `=~`, deliberately.
+    let c = if c0.Length = 0 then [| 1.0 |] else c0 |> Array.map (fun x -> if Util.IsNice(x) then x % 10. else 1.0)
+    let m = c.Length
+    if ks0.Length = 0 then true
+    else
+        // sorted, because the hand-built CSR transpose requires non-decreasing ks;
+        // gather itself does not care
+        let ks = ks0 |> Array.map (fun k -> abs (k % m)) |> Array.sort
+        let n = ks.Length
+        // the selection matrix and its transpose, exactly as WldMr.Analytics'
+        // InterpolateV builds them
+        let csrS =
+            { Values = Array.create n 1.; Columns = ks
+              RowIndices = Array.init (n + 1) id; NCols = m }
+        let csrST =
+            let colIndices = Array.zeroCreate (m + 1)
+            let mutable ksIdx = 0
+            for i in 0 .. m - 1 do
+                while ksIdx < n && i >= ks.[ksIdx] do ksIdx <- ksIdx + 1
+                colIndices.[i + 1] <- ksIdx
+            { Values = Array.create n 1.; Columns = Array.init n id
+              RowIndices = colIndices; NCols = n }
+        let seed = DV (Array.init n (fun i -> float (i % 7) - 3.0))
+
+        let ca = DV c |> makeReverse WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+        let yA : DV = DM (SparseDouble (csrS, csrST)) * ca
+        yA |> reverseProp seed
+        let pA = yA |> primal |> DV.toFloats
+        let gA = ca |> adjoint |> DV.toFloats
+
+        let cb = DV c |> makeReverse WldMr.Numerics.DiffSharp.Util.GlobalTagger.Next
+        let yB = DV.Gather(cb, ks)
+        yB |> reverseProp seed
+        let pB = yB |> primal |> DV.toFloats
+        let gB = cb |> adjoint |> DV.toFloats
+
+        pA = pB && gA = gB


### PR DESCRIPTION
**Stacked on #20** (`ad-lazy-adjoint-init`) — this PR shows only the gather
delta; GitHub will retarget it to `master` when #20 merges.

Implements `plans/ad-gather.md`: a differentiable `DV.Gather` (pick elements by
index) with `DV.Scatter` as its first-class adjoint, replacing the two hand-built
CSR selection matrices `WldMr.Analytics`' `InterpolateV` constructs on every
call — one of which exists purely so the reverse pass gets its transpose for
free.

## Design points

- **Bit-identical to the CSR formulation by construction.** `Scatter_V`
  accumulates duplicates in ascending index order — the same left fold per slot
  as the CSR-transpose mat-vec it replaces (§7 of the plan). Asserted three
  ways: an FsCheck property comparing the two formulations with exact `=` on
  primal and gradients; the `-- gather` harness mode, which asserts value and
  gradient bit-parity before printing any number; and the downstream
  fingerprint (below).
- **Push through the central accumulate**, not a seventeenth `.A <-` bypass:
  the materialized scatter vector is a fresh, uniquely-owned contribution
  (the ownership contract #19 established), and a `DVF` adjoint under nested
  AD dispatches through the ops' own `Op_DV_DV` cases.
- **Bounds validated always, on every target.** Fable→JS reads `undefined`
  (NaN after arithmetic) and silently drops writes out of bounds; Fable→Python
  wraps negatives; only .NET throws on its own. The bounds test runs under
  Fable because that is where it can fail.

## The performance lesson

As first written, validation called the `a.Length` property per element — a
DU-match the JIT can't hoist — and cost more than the mat-vec it replaced:
gather was **2.4x slower** than CSR in BDN despite allocating 33% less. The
bound is now hoisted and validation runs only in the public entry (a private
`*NoCheck` core serves the op's own primal/tangent recursion):

| method | Mean | Allocated |
| --- | ---: | ---: |
| CsrForward | 4.24 µs | 23.96 KB |
| **GatherForward** | **1.79 µs (0.42x)** | **16.07 KB (0.67x)** |
| CsrForwardAndReverse | 6.36 µs | 39.76 KB |
| **GatherForwardAndReverse** | **4.21 µs** | **31.66 KB** |

The reverse side is a wash by design — the materialized scatter vector replaces
`csrST * dA` one-for-one.

## Verification

- In-repo: 16 + 18 + 37 .NET (6 skipped, pre-existing), 18 Fable→JS, 18
  Fable→Python. New `GatherTests.fs` covers forward with duplicate/unsorted
  indices, scatter-must-ADD, fan-out, nested forward-over-reverse, and bounds
  on all three targets — the scatter-must-add and fan-out tests are the
  tripwires for the `resetRec`/`pushRec` wildcard arms, which let a forgotten
  `TraceOp` case compile clean.
- **Downstream, with the `InterpolateV` rewrite applied to Analytics' working
  tree against the local feed** (then reverted — it ships as the adoption PR
  once a release carries the op): all 445 .NET + 222 JS tests pass, the
  MarketBuild fingerprint is **byte-identical** across processes
  (`15a6fee3…`), and `-- stages 20` shows the whole fit at **54.7 → 50.0 MB
  (−8.6%)**, the saving inside `fitOisCurves`/`fitLocalSpreadCurves`/
  `bondCurves` — matching the plan's ~5.5 MB/fit attribution.

## Also

- `MochaFlip` gains `isTrue` in its Python branch (existed only for JS — the
  repo CLAUDE.md's both-branches rule, met in practice).
- `BenchmarkAdTape` gains the `GatherBenchmark` BDN class and the `-- gather`
  parity mode; `plans/ad-gather.md` records the outcome and the two
  corrections above.
